### PR TITLE
Add helper to configure branch protection

### DIFF
--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,45 @@
+# Branch Protection for `main`
+
+Dieses Projekt nutzt GitHub, daher lassen sich Branch-Protection-Regeln nicht
+allein durch eine Codeänderung aktivieren. Damit Administrator:innen die
+Absicherung des `main`-Branches schnell einrichten können, gibt es das Skript
+`scripts/apply-branch-protection.sh`.
+
+## Voraussetzungen
+
+- [GitHub CLI](https://cli.github.com/) (`gh`) ist lokal installiert.
+- Du hast Administrator:innenrechte für das Zielrepository.
+- Du bist über `gh auth login` authentifiziert **oder** setzt die Variable
+  `GITHUB_TOKEN` (wird automatisch als `GH_TOKEN` übernommen).
+
+## Verwendung
+
+```bash
+./scripts/apply-branch-protection.sh <owner/repo> [branch]
+```
+
+Beispiel für dieses Repository:
+
+```bash
+./scripts/apply-branch-protection.sh winter-guardians/winter-arc-app main
+```
+
+Der Standard-Branch ist `main`. Möchtest du einen anderen Branch schützen,
+übergib ihn als zweiten Parameter.
+
+## Eingestellte Regeln
+
+Das Skript konfiguriert folgende Schutzmechanismen:
+
+- Administrator:innen müssen die Regeln ebenfalls befolgen (`enforce_admins`).
+- Pull Requests benötigen mindestens eine Freigabe und veraltete Reviews werden
+  automatisch verworfen.
+- Force-Pushes, das Löschen des Branches und das Blockieren neuer Branches sind
+  deaktiviert.
+- Diskussionen in Pull Requests müssen vor dem Merge aufgelöst sein.
+- Syncs von Forks sind weiterhin erlaubt, ebenso wie ein linearer Verlauf.
+
+Diese Einstellungen können bei Bedarf direkt im Skript angepasst werden. Nach
+dem Ausführen meldet das Skript den Status des API-Aufrufs. Sollte ein Fehler
+auftreten (z. B. unzureichende Berechtigungen oder ein falscher Repositoryname),
+werden die Details ausgegeben.

--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/apply-branch-protection.sh <owner/repo> [branch]
+
+Apply a recommended branch protection rule set to the given GitHub repository
+and branch using the GitHub CLI (`gh`). The authenticated user must have admin
+permissions on the repository.
+
+Positional arguments:
+  <owner/repo>  The GitHub repository identifier, e.g. winter-guardians/app
+  [branch]      The branch to protect (defaults to "main")
+
+Environment variables:
+  GITHUB_TOKEN  Personal access token or fine-grained token with admin:repo or
+                appropriate repository administration permissions. When set,
+                the script will automatically export it so that `gh` can use it.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Error: invalid arguments" >&2
+  usage >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: GitHub CLI (gh) is required but not installed." >&2
+  exit 1
+fi
+
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  export GH_TOKEN="${GH_TOKEN:-$GITHUB_TOKEN}"
+fi
+
+REPO_SLUG="$1"
+BRANCH="${2:-main}"
+
+TMP_FILE=$(mktemp)
+trap 'rm -f "$TMP_FILE"' EXIT
+
+cat <<JSON >"$TMP_FILE"
+{
+  "required_status_checks": null,
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1,
+    "require_last_push_approval": false,
+    "bypass_pull_request_allowances": {
+      "users": [],
+      "teams": [],
+      "apps": []
+    }
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_linear_history": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": true
+}
+JSON
+
+set +e
+OUTPUT=$(gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$REPO_SLUG/branches/$BRANCH/protection" \
+  --input "$TMP_FILE" 2>&1)
+STATUS=$?
+set -e
+
+if [[ $STATUS -ne 0 ]]; then
+  echo "$OUTPUT" >&2
+  echo "Failed to apply branch protection. Ensure you have the necessary permissions and that the repository/branch exist." >&2
+  exit $STATUS
+fi
+
+echo "$OUTPUT"
+echo "Branch protection applied to $REPO_SLUG:$BRANCH."


### PR DESCRIPTION
## Summary
- add a shell script that applies recommended branch protection settings through the GitHub API
- document the usage and defaults for the branch protection helper

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4dddc41c883339438d097f8e011c0