### PR TITLE
Make week overview card span full tile width

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -96,7 +96,9 @@ function DashboardPage() {
 
         {/* Week Compact Card */}
         <div className="tile-grid-2 mb-3 animate-fade-in-up delay-100">
-          <WeekCompactCard />
+          <div className="col-span-full">
+            <WeekCompactCard />
+          </div>
         </div>
 
         {/* Tracking Tiles */}


### PR DESCRIPTION
## Summary
- ensure the week overview tile spans all grid columns so it stretches across the dashboard width

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4e7e8a358833398fe4cfdd11ddb47