### PR TITLE
Add week navigation controls to dashboard week view

### DIFF
--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -13,6 +13,11 @@ export const translations = {
     dashboard: {
       greeting: 'Hey, {{nickname}}! 👋',
       weekOverview: 'Diese Woche',
+      lastWeek: 'Letzte Woche',
+      weekNumberTitle: 'KW {{week}}',
+      weekRangeLabel: '{{range}}',
+      previousWeek: 'Vorherige Woche',
+      nextWeek: 'Nächste Woche',
       days: 'Tage',
       completed: 'abgeschlossen',
       streak: 'Tage Streak',
@@ -238,6 +243,11 @@ export const translations = {
     dashboard: {
       greeting: 'Hey, {{nickname}}! 👋',
       weekOverview: 'This Week',
+      lastWeek: 'Last Week',
+      weekNumberTitle: 'Week {{week}}',
+      weekRangeLabel: '{{range}}',
+      previousWeek: 'Previous week',
+      nextWeek: 'Next week',
       days: 'days',
       completed: 'completed',
       streak: 'Day Streak',


### PR DESCRIPTION
## Summary
- add previous/next week navigation controls to the Dashboard week overview card and preserve the selected weekday when switching weeks
- show the current week range with dynamic headings while preventing navigation into future weeks
- extend the dashboard translations with the labels required for the new controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4e979de088333819292abf5cda25c