### PR TITLE
Refactor notes page into smart timeline with AI pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@google/generative-ai": "^0.21.0",
         "@sentry/react": "^10.17.0",
         "date-fns": "^4.1.0",
+        "dexie": "^4.0.11",
         "firebase": "^11.10.0",
         "framer-motion": "^12.23.22",
         "lucide-react": "^0.544.0",
@@ -7566,6 +7567,12 @@
       "integrity": "sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dexie": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.2.1.tgz",
+      "integrity": "sha512-Ckej0NS6jxQ4Po3OrSQBFddayRhTCic2DoCAG5zacOfOVB9P2Q5Xc5uL/nVa7ZVs+HdMnvUPzLFCB/JwpB6Csg==",
+      "license": "Apache-2.0"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
+    "dexie": "^4.0.11",
     "@sentry/react": "^10.17.0",
     "date-fns": "^4.1.0",
     "firebase": "^11.10.0",

--- a/src/__tests__/NotesPage.test.tsx
+++ b/src/__tests__/NotesPage.test.tsx
@@ -1,0 +1,113 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import NotesPage from '../pages/NotesPage';
+import { SmartNote } from '../types/events';
+
+const storeState = vi.hoisted(() => ({
+  notes: [] as SmartNote[],
+  listeners: new Set<() => void>(),
+}));
+
+const noteStoreMock = vi.hoisted(() => {
+  const emit = () => {
+    for (const listener of storeState.listeners) {
+      listener();
+    }
+  };
+
+  return {
+    async add(note: SmartNote) {
+      storeState.notes = [note, ...storeState.notes];
+      emit();
+    },
+    async update(id: string, patch: Partial<SmartNote>) {
+      storeState.notes = storeState.notes.map((note) => (note.id === id ? { ...note, ...patch } : note));
+      emit();
+    },
+    async list({ limit }: { limit?: number }) {
+      const safeLimit = limit ?? 20;
+      const slice = storeState.notes.slice(0, safeLimit);
+      return { notes: slice, hasMore: storeState.notes.length > safeLimit };
+    },
+    async todayAggregates() {
+      return {
+        waterMl: 0,
+        proteinG: 0,
+        pushups: 0,
+        workoutsBySport: {},
+        isRestDay: false,
+        lastWeightKg: undefined,
+        lastBfpPercent: undefined,
+      };
+    },
+    async getRecent() {
+      return storeState.notes.slice(0, 5);
+    },
+    async get(id: string) {
+      return storeState.notes.find((note) => note.id === id);
+    },
+    subscribe(listener: () => void) {
+      storeState.listeners.add(listener);
+      return () => storeState.listeners.delete(listener);
+    },
+  };
+});
+
+vi.mock('../store/noteStore', () => ({ noteStore: noteStoreMock }));
+
+vi.mock('../features/notes/pipeline', () => {
+  return {
+    processSmartNote: vi.fn(async (raw: string) => {
+      const note: SmartNote = {
+        id: `note-${Math.random().toString(16).slice(2)}`,
+        ts: Date.now(),
+        raw,
+        summary: raw,
+        events: [],
+        pending: true,
+      };
+      await noteStoreMock.add(note);
+      setTimeout(() => {
+        void noteStoreMock.update(note.id, {
+          summary: `Processed: ${raw}`,
+          pending: false,
+        });
+      }, 150);
+      return { noteId: note.id };
+    }),
+    retrySmartNote: vi.fn(),
+  };
+});
+
+describe('NotesPage', () => {
+  beforeEach(() => {
+    storeState.notes = [];
+    storeState.listeners.clear();
+    localStorage.clear();
+  });
+
+  it('shows optimistic note and patches after processing', async () => {
+    render(<NotesPage />);
+
+    const input = screen.getByPlaceholderText('Kurz notieren…');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '20 Liegestütze, 500 ml Wasser, Proteinshake' } });
+    });
+
+    const submit = screen.getByRole('button', { name: 'Hinzufügen' });
+    await act(async () => {
+      fireEvent.click(submit);
+    });
+
+    expect(await screen.findByTitle('Wird verarbeitet')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Processed:/)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTitle('Wird verarbeitet')).not.toBeInTheDocument();
+    });
+  });
+});
+

--- a/src/__tests__/parsers.test.ts
+++ b/src/__tests__/parsers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { parseHeuristic } from '../lib/parsers';
+
+describe('parseHeuristic', () => {
+  it('parses drink quantities with decimal comma', () => {
+    const { candidates } = parseHeuristic('0,5 l Wasser getrunken');
+    const drink = candidates.find((event) => event.kind === 'drink');
+    expect(drink).toBeDefined();
+    expect(drink?.volumeMl).toBe(500);
+  });
+
+  it('parses pushups in German', () => {
+    const { candidates } = parseHeuristic('20 Liegestütze fertig');
+    const pushups = candidates.find((event) => event.kind === 'pushups');
+    expect(pushups).toBeDefined();
+    expect(pushups?.count).toBe(20);
+  });
+
+  it('guesses protein shake when no grams provided', () => {
+    const { candidates } = parseHeuristic('Proteinshake nach dem Workout');
+    const protein = candidates.find((event) => event.kind === 'protein');
+    expect(protein).toBeDefined();
+    expect(protein?.grams).toBe(25);
+    expect(protein?.confidence).toBeLessThan(0.6);
+  });
+});
+

--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { mergeEvents } from '../features/notes/pipeline';
+import { Event, ProteinEvent } from '../types/events';
+
+describe('mergeEvents', () => {
+  const baseTs = Date.now();
+
+  const heuristicDrink: Event = {
+    id: 'h1',
+    ts: baseTs,
+    kind: 'drink',
+    confidence: 0.6,
+    source: 'heuristic',
+    volumeMl: 500,
+    beverage: 'water',
+  };
+
+  const llmDrink: Event = {
+    id: 'l1',
+    ts: baseTs,
+    kind: 'drink',
+    confidence: 0.9,
+    source: 'llm',
+    volumeMl: 500,
+    beverage: 'water',
+  };
+
+  const heuristicProtein: Event = {
+    id: 'h2',
+    ts: baseTs,
+    kind: 'protein',
+    confidence: 0.6,
+    source: 'heuristic',
+    grams: 25,
+  };
+
+  const llmProtein: Event = {
+    id: 'l2',
+    ts: baseTs,
+    kind: 'protein',
+    confidence: 0.4,
+    source: 'llm',
+    grams: 20,
+  };
+
+  it('keeps higher confidence event when duplicate', () => {
+    const merged = mergeEvents([heuristicDrink], [llmDrink]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe('l1');
+    expect(merged[0].source).toBe('llm');
+  });
+
+  it('keeps heuristic value when LLM is less confident', () => {
+    const merged = mergeEvents([heuristicProtein], [llmProtein]);
+    expect(merged).toHaveLength(1);
+    const protein = merged[0] as ProteinEvent;
+    expect(protein.grams).toBe(25);
+    expect(protein.source).toBe('heuristic');
+  });
+});
+

--- a/src/features/notes/pipeline.ts
+++ b/src/features/notes/pipeline.ts
@@ -1,0 +1,233 @@
+import { parseHeuristic } from '../../lib/parsers';
+import { summarizeAndValidate } from '../../services/gemini';
+import { noteStore } from '../../store/noteStore';
+import { Event, SmartNote } from '../../types/events';
+
+const RECENT_LIMIT = 5;
+
+function createEventId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function normalizeEvent(event: Event, noteTs: number, source: Event['source']): Event {
+  return {
+    ...event,
+    id: event.id ?? createEventId(),
+    ts: noteTs,
+    source,
+    confidence: typeof event.confidence === 'number' ? event.confidence : 0.5,
+  } as Event;
+}
+
+function fingerprint(event: Event): string {
+  switch (event.kind) {
+    case 'drink':
+      return `${event.kind}:${event.beverage}:${Math.round(event.volumeMl)}`;
+    case 'protein':
+      return `${event.kind}:${Math.round(event.grams)}`;
+    case 'pushups':
+      return `${event.kind}:${event.count}`;
+    case 'workout':
+      return `${event.kind}:${event.sport}:${event.durationMin ?? 'na'}:${event.intensity ?? 'na'}`;
+    case 'rest':
+      return `${event.kind}:${event.reason ?? ''}`;
+    case 'weight':
+      return `${event.kind}:${event.kg}`;
+    case 'bfp':
+      return `${event.kind}:${event.percent}`;
+    case 'food':
+      return `${event.kind}:${event.label}`;
+  }
+  throw new Error('Unsupported event kind');
+}
+
+function isSimilarEvent(a: Event, b: Event): boolean {
+  if (a.kind !== b.kind) return false;
+  switch (a.kind) {
+    case 'drink':
+      if (b.kind !== 'drink') return false;
+      return a.beverage === b.beverage && Math.abs(a.volumeMl - b.volumeMl) <= 60;
+    case 'protein':
+      if (b.kind !== 'protein') return false;
+      return Math.abs(a.grams - b.grams) <= 6;
+    case 'pushups':
+      if (b.kind !== 'pushups') return false;
+      return Math.abs(a.count - b.count) <= 2;
+    case 'workout':
+      if (b.kind !== 'workout') return false;
+      return (
+        a.sport === b.sport &&
+        (a.durationMin === undefined || b.durationMin === undefined || Math.abs((a.durationMin ?? 0) - (b.durationMin ?? 0)) <= 10) &&
+        (a.intensity === b.intensity || !a.intensity || !b.intensity)
+      );
+    case 'rest':
+      if (b.kind !== 'rest') return false;
+      return true;
+    case 'weight':
+      if (b.kind !== 'weight') return false;
+      return Math.abs(a.kg - b.kg) <= 0.2;
+    case 'bfp':
+      if (b.kind !== 'bfp') return false;
+      return Math.abs(a.percent - b.percent) <= 0.3;
+    case 'food':
+      if (b.kind !== 'food') return false;
+      return a.label === b.label;
+  }
+  return false;
+}
+
+function resolveKey(store: Map<string, Event>, event: Event): string {
+  const exactKey = fingerprint(event);
+  if (store.has(exactKey)) {
+    return exactKey;
+  }
+  for (const [key, existing] of store.entries()) {
+    if (isSimilarEvent(existing, event)) {
+      return key;
+    }
+  }
+  return exactKey;
+}
+
+export function mergeEvents(candidates: Event[], llmEvents: Event[]): Event[] {
+  const merged = new Map<string, Event>();
+
+  for (const candidate of candidates) {
+    merged.set(fingerprint(candidate), candidate);
+  }
+
+  for (const event of llmEvents) {
+    const key = resolveKey(merged, event);
+    const existing = merged.get(key);
+    if (!existing) {
+      merged.set(key, event);
+      continue;
+    }
+    if ((event.confidence ?? 0) >= (existing.confidence ?? 0)) {
+      merged.set(key, event);
+    }
+  }
+
+  return Array.from(merged.values());
+}
+
+function createOptimisticSummary(raw: string) {
+  if (raw.length < 120) {
+    return raw;
+  }
+  return `${raw.slice(0, 117)}...`;
+}
+
+export async function processSmartNote(rawInput: string, options: { autoTracking: boolean } = { autoTracking: true }) {
+  const raw = rawInput.trim();
+  if (!raw) {
+    throw new Error('Empty input');
+  }
+
+  const ts = Date.now();
+  const noteId = createEventId();
+
+  if (!options.autoTracking) {
+    const note: SmartNote = {
+      id: noteId,
+      ts,
+      raw,
+      summary: raw,
+      events: [],
+    };
+    await noteStore.add(note);
+    return { noteId };
+  }
+
+  const heuristic = parseHeuristic(raw);
+  const optimisticEvents = heuristic.candidates.map((candidate) => normalizeEvent(candidate, ts, 'heuristic'));
+
+  const optimisticNote: SmartNote = {
+    id: noteId,
+    ts,
+    raw,
+    summary: createOptimisticSummary(raw),
+    events: optimisticEvents,
+    pending: true,
+  };
+
+  await noteStore.add(optimisticNote);
+
+  const recentNotes = await noteStore.getRecent(RECENT_LIMIT);
+
+  (async () => {
+    try {
+      const result = await summarizeAndValidate({
+        raw,
+        recentNotes,
+        candidates: optimisticEvents,
+      });
+      const llmEvents = Array.isArray(result.events)
+        ? result.events.map((event) => normalizeEvent(event, ts, 'llm'))
+        : [];
+      const mergedEvents = mergeEvents(optimisticEvents, llmEvents).map((event) => ({
+        ...event,
+        ts,
+      }));
+      await noteStore.update(noteId, {
+        summary: result.summary || createOptimisticSummary(raw),
+        events: mergedEvents,
+        pending: false,
+      });
+    } catch (error) {
+      console.error('Gemini summarization failed', error);
+      await noteStore.update(noteId, {
+        summary: createOptimisticSummary(raw),
+        pending: true,
+      });
+    }
+  })();
+
+  return { noteId };
+}
+
+export async function retrySmartNote(noteId: string) {
+  const existing = await noteStore.get(noteId);
+  if (!existing) return;
+
+  await noteStore.update(noteId, { pending: true });
+
+  const ts = existing.ts;
+  const heuristic = parseHeuristic(existing.raw);
+  const heuristicEvents = heuristic.candidates.map((candidate) => normalizeEvent(candidate, ts, 'heuristic'));
+
+  await noteStore.update(noteId, {
+    events: heuristicEvents,
+  });
+
+  const recentNotes = await noteStore.getRecent(RECENT_LIMIT + 1);
+
+  try {
+    const result = await summarizeAndValidate({
+      raw: existing.raw,
+      recentNotes,
+      candidates: heuristicEvents,
+    });
+    const llmEvents = Array.isArray(result.events)
+      ? result.events.map((event) => normalizeEvent(event, ts, 'llm'))
+      : [];
+    const mergedEvents = mergeEvents(heuristicEvents, llmEvents).map((event) => ({
+      ...event,
+      ts,
+    }));
+    await noteStore.update(noteId, {
+      summary: result.summary || createOptimisticSummary(existing.raw),
+      events: mergedEvents,
+      pending: false,
+    });
+  } catch (error) {
+    console.error('Gemini retry failed', error);
+    await noteStore.update(noteId, {
+      pending: true,
+    });
+  }
+}
+

--- a/src/lib/parsers.ts
+++ b/src/lib/parsers.ts
@@ -1,0 +1,259 @@
+import { Event, EventKind } from '../types/events';
+
+const beverageKeywords: Record<string, 'water' | 'protein' | 'coffee' | 'tea' | 'other'> = {
+  wasser: 'water',
+  water: 'water',
+  'stilles wasser': 'water',
+  'sparkling water': 'water',
+  protein: 'protein',
+  proteinshake: 'protein',
+  shake: 'protein',
+  kaffee: 'coffee',
+  coffee: 'coffee',
+  espresso: 'coffee',
+  tee: 'tea',
+  tea: 'tea',
+};
+
+const workoutKeywords: Record<string, 'hiit_hyrox' | 'cardio' | 'gym' | 'swimming' | 'football' | 'other'> = {
+  hiit: 'hiit_hyrox',
+  hyrox: 'hiit_hyrox',
+  cardio: 'cardio',
+  laufen: 'cardio',
+  joggen: 'cardio',
+  run: 'cardio',
+  running: 'cardio',
+  jog: 'cardio',
+  cycling: 'cardio',
+  rad: 'cardio',
+  bike: 'cardio',
+  radfahren: 'cardio',
+  schwimmen: 'swimming',
+  swimming: 'swimming',
+  schwimm: 'swimming',
+  gym: 'gym',
+  kraft: 'gym',
+  krafttraining: 'gym',
+  workout: 'gym',
+  training: 'gym',
+  fußball: 'football',
+  fussball: 'football',
+  football: 'football',
+  soccer: 'football',
+};
+
+const foodKeywords = [
+  'porridge',
+  'oatmeal',
+  'haferbrei',
+  'tofu',
+  'reis',
+  'rice',
+  'nudeln',
+  'pasta',
+  'salat',
+  'salad',
+  'smoothie',
+  'burger',
+  'sandwich',
+  'wrap',
+  'quark',
+  'yogurt',
+  'joghurt',
+];
+
+const intensityMap: Record<string, 'easy' | 'moderate' | 'hard'> = {
+  locker: 'easy',
+  leicht: 'easy',
+  easy: 'easy',
+  moderat: 'moderate',
+  moderate: 'moderate',
+  hart: 'hard',
+  streng: 'hard',
+  hard: 'hard',
+  intense: 'hard',
+};
+
+const DECIMAL_REGEX = /,/g;
+
+const FOOD_CALORIES_REGEX = /(\d+(?:[.,]\d+)?)\s?(kcal|cal(?:orien)?)\b/i;
+const FOOD_PROTEIN_REGEX = /(\d+(?:[.,]\d+)?)\s?(g|gramm|grams?)\b.*(protein|eiweiß)/i;
+
+const DEFAULT_CONFIDENCE = 0.6;
+
+function toNumber(value: string): number {
+  return Number.parseFloat(value.replace(',', '.'));
+}
+
+function createEventId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function buildBase<K extends EventKind>(kind: K, confidence: number) {
+  return {
+    id: createEventId(),
+    ts: Date.now(),
+    kind,
+    confidence,
+    source: 'heuristic' as const,
+  };
+}
+
+function detectBeverage(raw: string): 'water' | 'protein' | 'coffee' | 'tea' | 'other' {
+  const lower = raw.toLowerCase();
+  for (const [keyword, value] of Object.entries(beverageKeywords)) {
+    if (lower.includes(keyword)) {
+      return value;
+    }
+  }
+  if (lower.includes('protein')) {
+    return 'protein';
+  }
+  return 'other';
+}
+
+function findDuration(raw: string): number | undefined {
+  const durationMatch = raw.match(/(\d+(?:[.,]\d+)?)\s?(min|minutes?|mins?|h|stunden?|hours?)/i);
+  if (!durationMatch) return undefined;
+  const value = toNumber(durationMatch[1]);
+  const unit = durationMatch[2].toLowerCase();
+  if (unit.startsWith('h')) {
+    return Math.round(value * 60);
+  }
+  return Math.round(value);
+}
+
+function findIntensity(raw: string): 'easy' | 'moderate' | 'hard' | undefined {
+  const lower = raw.toLowerCase();
+  for (const [keyword, intensity] of Object.entries(intensityMap)) {
+    if (lower.includes(keyword)) {
+      return intensity;
+    }
+  }
+  return undefined;
+}
+
+function detectSport(raw: string): 'hiit_hyrox' | 'cardio' | 'gym' | 'swimming' | 'football' | 'other' {
+  const lower = raw.toLowerCase();
+  for (const [keyword, sport] of Object.entries(workoutKeywords)) {
+    if (lower.includes(keyword)) {
+      return sport;
+    }
+  }
+  return 'other';
+}
+
+export function parseHeuristic(raw: string): { raw: string; candidates: Event[] } {
+  const normalized = raw.replace(DECIMAL_REGEX, '.');
+  const lower = normalized.toLowerCase();
+  const candidates: Event[] = [];
+
+  const drinkRegex = /(\d+(?:\.\d+)?)\s?(ml|l)\b/gi;
+  let drinkMatch: RegExpExecArray | null;
+  while ((drinkMatch = drinkRegex.exec(normalized))) {
+    const value = Number.parseFloat(drinkMatch[1]);
+    const unit = drinkMatch[2].toLowerCase();
+    const volumeMl = unit === 'l' ? Math.round(value * 1000) : Math.round(value);
+    const drinkEvent = {
+      ...buildBase('drink', DEFAULT_CONFIDENCE),
+      volumeMl,
+      beverage: detectBeverage(lower),
+    } satisfies Event;
+    candidates.push(drinkEvent);
+  }
+
+  const proteinRegex = /(\d+(?:\.\d+)?)\s?(g|gramm|grams?)\b/gi;
+  let proteinMatch: RegExpExecArray | null;
+  let foundProteinValue = false;
+  while ((proteinMatch = proteinRegex.exec(normalized))) {
+    const grams = Math.round(Number.parseFloat(proteinMatch[1]));
+    const proteinEvent = {
+      ...buildBase('protein', DEFAULT_CONFIDENCE),
+      grams,
+      sourceLabel: lower.includes('shake') || lower.includes('protein') ? 'protein' : undefined,
+    } satisfies Event;
+    candidates.push(proteinEvent);
+    foundProteinValue = true;
+  }
+
+  if (lower.includes('proteinshake') && !foundProteinValue) {
+    const shakeEvent = {
+      ...buildBase('protein', 0.5),
+      grams: 25,
+      sourceLabel: 'proteinshake',
+    } satisfies Event;
+    candidates.push(shakeEvent);
+  }
+
+  const pushupRegex = /(\d+)\s?(liegestütze|liegestuetze|push[- ]?ups?)\b/gi;
+  let pushupMatch: RegExpExecArray | null;
+  while ((pushupMatch = pushupRegex.exec(lower))) {
+    const count = Number.parseInt(pushupMatch[1], 10);
+    const pushupEvent = {
+      ...buildBase('pushups', DEFAULT_CONFIDENCE),
+      count,
+    } satisfies Event;
+    candidates.push(pushupEvent);
+  }
+
+  const workoutMatch = /(workout|training|hiit|hyrox|laufen|joggen|run|gym|schwimmen|swimming|fußball|fussball|football|cardio)/i.test(lower);
+  if (workoutMatch) {
+    const workoutEvent = {
+      ...buildBase('workout', DEFAULT_CONFIDENCE),
+      sport: detectSport(lower),
+      durationMin: findDuration(lower),
+      intensity: findIntensity(lower),
+      notes: raw,
+    } satisfies Event;
+    candidates.push(workoutEvent);
+  }
+
+  if (/(ausruhen|rest ?day|pause)/i.test(lower)) {
+    const restEvent = {
+      ...buildBase('rest', DEFAULT_CONFIDENCE),
+      reason: /wegen\s+([^.,;]+)/i.exec(normalized)?.[1],
+    } satisfies Event;
+    candidates.push(restEvent);
+  }
+
+  const weightRegex = /(\d+(?:\.\d+)?)\s?kg\b/i;
+  const weightMatch = weightRegex.exec(normalized);
+  if (weightMatch) {
+    const weightEvent = {
+      ...buildBase('weight', DEFAULT_CONFIDENCE),
+      kg: Number.parseFloat(weightMatch[1]),
+    } satisfies Event;
+    candidates.push(weightEvent);
+  }
+
+  const bfpRegex = /(\d+(?:\.\d+)?)\s?%\b/i;
+  const bfpMatch = bfpRegex.exec(normalized);
+  if (bfpMatch) {
+    const bfpEvent = {
+      ...buildBase('bfp', DEFAULT_CONFIDENCE),
+      percent: Number.parseFloat(bfpMatch[1]),
+    } satisfies Event;
+    candidates.push(bfpEvent);
+  }
+
+  for (const keyword of foodKeywords) {
+    if (lower.includes(keyword)) {
+      const caloriesMatch = FOOD_CALORIES_REGEX.exec(lower);
+      const proteinInfo = FOOD_PROTEIN_REGEX.exec(lower);
+      const foodEvent = {
+        ...buildBase('food', DEFAULT_CONFIDENCE),
+        label: keyword,
+        calories: caloriesMatch ? Math.round(toNumber(caloriesMatch[1])) : undefined,
+        proteinG: proteinInfo ? Math.round(toNumber(proteinInfo[1])) : undefined,
+      } satisfies Event;
+      candidates.push(foodEvent);
+      break;
+    }
+  }
+
+  return { raw, candidates };
+}
+

--- a/src/pages/NotesPage.tsx
+++ b/src/pages/NotesPage.tsx
@@ -1,92 +1,362 @@
-import { useState, useEffect } from 'react';
-import { useStore } from '../store/useStore';
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
 import { useTranslation } from '../hooks/useTranslation';
-import { getNotes, saveNotes } from '../services/firestoreService';
+import { SmartNote, Event } from '../types/events';
+import { noteStore } from '../store/noteStore';
+import { processSmartNote, retrySmartNote } from '../features/notes/pipeline';
+
+const PAGE_SIZE = 20;
+
+type Aggregates = Awaited<ReturnType<typeof noteStore.todayAggregates>>;
+
+function useAutoTracking() {
+  const [autoTracking, setAutoTracking] = useState(() => {
+    if (typeof window === 'undefined') {
+      return true;
+    }
+    try {
+      const stored = localStorage.getItem('smart_notes_auto_tracking');
+      return stored ? JSON.parse(stored) : true;
+    } catch {
+      return true;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem('smart_notes_auto_tracking', JSON.stringify(autoTracking));
+    } catch (error) {
+      console.warn('Failed to persist auto-tracking preference', error);
+    }
+  }, [autoTracking]);
+
+  return [autoTracking, setAutoTracking] as const;
+}
+
+function getBeverageLabel(beverage: 'water' | 'protein' | 'coffee' | 'tea' | 'other') {
+  switch (beverage) {
+    case 'water':
+      return 'Wasser';
+    case 'protein':
+      return 'Protein';
+    case 'coffee':
+      return 'Kaffee';
+    case 'tea':
+      return 'Tee';
+    default:
+      return 'Drink';
+  }
+}
+
+function getWorkoutLabel(sport: string) {
+  switch (sport) {
+    case 'hiit_hyrox':
+      return 'Hyrox/HIIT';
+    case 'cardio':
+      return 'Cardio';
+    case 'gym':
+      return 'Gym';
+    case 'swimming':
+      return 'Schwimmen';
+    case 'football':
+      return 'Football';
+    default:
+      return sport;
+  }
+}
+
+function EventBadges({ events }: { events: Event[] }) {
+  if (!events.length) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 mt-3">
+      {events.map((event) => {
+        const baseClass = 'px-3 py-1 rounded-full text-sm bg-winter-100 text-winter-700 dark:bg-winter-900/40 dark:text-winter-100 flex items-center gap-1';
+        const confidenceLow = event.confidence < 0.5;
+
+        switch (event.kind) {
+          case 'drink':
+            return (
+              <span key={event.id} className={baseClass}>
+                🥤 {event.volumeMl} ml {getBeverageLabel(event.beverage)}
+                {confidenceLow && <span className="ml-2 text-xs">⚠︎ prüfen</span>}
+              </span>
+            );
+          case 'protein':
+            return (
+              <span key={event.id} className={baseClass}>
+                🧬 {event.grams} g
+                {event.sourceLabel ? <span className="ml-1">({event.sourceLabel})</span> : null}
+                {confidenceLow && <span className="ml-2 text-xs">⚠︎ prüfen</span>}
+              </span>
+            );
+          case 'pushups':
+            return (
+              <span key={event.id} className={baseClass}>
+                💪 ×{event.count}
+                {confidenceLow && <span className="ml-2 text-xs">⚠︎ prüfen</span>}
+              </span>
+            );
+          case 'workout':
+            return (
+              <span key={event.id} className={baseClass}>
+                🏋️ {getWorkoutLabel(event.sport)}
+                {event.durationMin ? <span className="ml-1">· {event.durationMin} min</span> : null}
+                {event.intensity ? <span className="ml-1">· {event.intensity}</span> : null}
+                {confidenceLow && <span className="ml-2 text-xs">⚠︎ prüfen</span>}
+              </span>
+            );
+          case 'rest':
+            return (
+              <span key={event.id} className={baseClass}>
+                😴 Rest-Day
+                {event.reason ? <span className="ml-1">({event.reason})</span> : null}
+                {confidenceLow && <span className="ml-2 text-xs">⚠︎ prüfen</span>}
+              </span>
+            );
+          case 'weight':
+            return (
+              <span key={event.id} className={baseClass}>
+                ⚖️ {event.kg} kg
+                {confidenceLow && <span className="ml-2 text-xs">⚠︎ prüfen</span>}
+              </span>
+            );
+          case 'bfp':
+            return (
+              <span key={event.id} className={baseClass}>
+                📉 {event.percent} %
+                {confidenceLow && <span className="ml-2 text-xs">⚠︎ prüfen</span>}
+              </span>
+            );
+          case 'food':
+            return (
+              <span key={event.id} className={baseClass}>
+                🍽️ {event.label}
+                {typeof event.calories === 'number' ? <span className="ml-1">· {event.calories} kcal</span> : null}
+                {typeof event.proteinG === 'number' ? <span className="ml-1">· {event.proteinG} g Protein</span> : null}
+                {confidenceLow && <span className="ml-2 text-xs">⚠︎ prüfen</span>}
+              </span>
+            );
+          default:
+            return null;
+        }
+      })}
+    </div>
+  );
+}
+
+function AggregatesBar({ aggregates }: { aggregates: Aggregates }) {
+  const workoutSummary = useMemo(() => {
+    const entries = Object.entries(aggregates.workoutsBySport ?? {});
+    if (!entries.length) return '–';
+    return entries
+      .map(([sport, count]) => `${getWorkoutLabel(sport)} (${count})`)
+      .join(', ');
+  }, [aggregates.workoutsBySport]);
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-gray-700 dark:text-gray-200">
+      <div className="glass dark:glass-dark rounded-xl p-4 flex flex-col">
+        <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Wasser</span>
+        <span className="text-lg font-semibold">{aggregates.waterMl} ml</span>
+      </div>
+      <div className="glass dark:glass-dark rounded-xl p-4 flex flex-col">
+        <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Protein</span>
+        <span className="text-lg font-semibold">{aggregates.proteinG} g</span>
+      </div>
+      <div className="glass dark:glass-dark rounded-xl p-4 flex flex-col">
+        <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Push-ups</span>
+        <span className="text-lg font-semibold">{aggregates.pushups}</span>
+      </div>
+      <div className="glass dark:glass-dark rounded-xl p-4 flex flex-col">
+        <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Workouts</span>
+        <span className="text-lg font-semibold">{workoutSummary}</span>
+      </div>
+      <div className="glass dark:glass-dark rounded-xl p-4 flex flex-col">
+        <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Rest Day</span>
+        <span className="text-lg font-semibold">{aggregates.isRestDay ? 'Ja' : 'Nein'}</span>
+      </div>
+      <div className="glass dark:glass-dark rounded-xl p-4 flex flex-col">
+        <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Letzte Werte</span>
+        <span className="text-lg font-semibold">
+          {(() => {
+            const parts: string[] = [];
+            if (typeof aggregates.lastWeightKg === 'number') {
+              parts.push(`⚖️ ${aggregates.lastWeightKg} kg`);
+            }
+            if (typeof aggregates.lastBfpPercent === 'number') {
+              parts.push(`📉 ${aggregates.lastBfpPercent} %`);
+            }
+            return parts.length ? parts.join(' · ') : '–';
+          })()}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function NoteCard({ note }: { note: SmartNote }) {
+  const createdAgo = formatDistanceToNow(note.ts, { addSuffix: true });
+
+  return (
+    <div className="glass dark:glass-dark rounded-2xl p-5 shadow-sm transition-all">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">{createdAgo}</div>
+          <p className="mt-2 text-base text-gray-900 dark:text-gray-100 leading-relaxed">
+            {note.summary}
+            {note.pending && <span className="ml-2" title="Wird verarbeitet">⏳</span>}
+          </p>
+        </div>
+        {note.pending && (
+          <button
+            className="text-sm text-winter-600 hover:text-winter-500 dark:text-winter-300"
+            onClick={() => retrySmartNote(note.id)}
+            type="button"
+          >
+            Erneut prüfen
+          </button>
+        )}
+      </div>
+      <EventBadges events={note.events} />
+    </div>
+  );
+}
 
 function NotesPage() {
   const { t } = useTranslation();
-  const user = useStore((state) => state.user);
-  const [notes, setNotes] = useState('');
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [input, setInput] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [notes, setNotes] = useState<SmartNote[]>([]);
+  const [aggregates, setAggregates] = useState<Aggregates>({
+    waterMl: 0,
+    proteinG: 0,
+    pushups: 0,
+    workoutsBySport: {} as Record<'cardio' | 'gym' | 'other' | 'hiit_hyrox' | 'swimming' | 'football', number>,
+    isRestDay: false,
+    lastWeightKg: undefined,
+    lastBfpPercent: undefined,
+  });
+  const [autoTracking, setAutoTracking] = useAutoTracking();
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const limitRef = useRef(PAGE_SIZE);
 
-  // Load notes on mount
+  const loadNotes = useCallback(async (limit = limitRef.current) => {
+    const { notes: fetched, hasMore: more } = await noteStore.list({ limit });
+    setNotes(fetched);
+    setHasMore(more);
+    limitRef.current = limit;
+  }, []);
+
+  const refreshAggregates = useCallback(async () => {
+    const data = await noteStore.todayAggregates();
+    setAggregates(data);
+  }, []);
+
   useEffect(() => {
-    const loadNotes = async () => {
-      if (!user) return;
-      const result = await getNotes(user.id);
-      if (result.success && result.data) {
-        setNotes(result.data);
-      }
-    };
     loadNotes();
-  }, [user]);
+    refreshAggregates();
+    const unsubscribe = noteStore.subscribe(() => {
+      loadNotes();
+      refreshAggregates();
+    });
+    return unsubscribe;
+  }, [loadNotes, refreshAggregates]);
 
-  const handleSave = async () => {
-    if (!user) return;
-    setIsSaving(true);
-    setSaveStatus('idle');
+  const onSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!input.trim()) return;
+      setIsSubmitting(true);
+      try {
+        await processSmartNote(input, { autoTracking });
+        setInput('');
+      } catch (error) {
+        console.error('Failed to process note', error);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [input, autoTracking]
+  );
 
-    const result = await saveNotes(user.id, notes);
-
-    if (result.success) {
-      setSaveStatus('success');
-      setTimeout(() => setSaveStatus('idle'), 3000);
-    } else {
-      setSaveStatus('error');
-      setTimeout(() => setSaveStatus('idle'), 3000);
-    }
-
-    setIsSaving(false);
-  };
+  const handleLoadMore = useCallback(async () => {
+    if (loadingMore || !hasMore) return;
+    setLoadingMore(true);
+    const nextLimit = limitRef.current + PAGE_SIZE;
+    await loadNotes(nextLimit);
+    setLoadingMore(false);
+  }, [hasMore, loadingMore, loadNotes]);
 
   return (
     <div className="min-h-screen safe-area-inset-top">
-      {/* Header */}
       <div className="relative text-white p-6 pb-8">
-        <div className="max-w-7xl mx-auto relative z-10">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
-            📝 {t('notes.title')}
-          </h1>
-          <p className="text-gray-600 dark:text-gray-400">{t('notes.subtitle')}</p>
+        <div className="max-w-[700px] mx-auto relative z-10">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">🧠 {t('notes.title')}</h1>
+          <p className="text-gray-600 dark:text-gray-400">Smart Notes helfen dir, Aktivitäten automatisch zu tracken.</p>
         </div>
       </div>
 
-      {/* Content */}
-      <div className="max-w-7xl mx-auto px-4 pt-4 md:pt-6 pb-20 space-y-4">
-        <div className="glass dark:glass-dark rounded-[20px] p-6">
-          <textarea
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            placeholder={t('notes.placeholder')}
-            className="w-full h-96 px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-winter-500 outline-none resize-none"
+      <div className="max-w-[700px] mx-auto px-4 pt-4 md:pt-6 pb-20 space-y-6">
+        <form onSubmit={onSubmit} className="glass dark:glass-dark rounded-2xl p-5 flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Kurz notieren…"
+            className="flex-1 px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-winter-500 outline-none"
+            disabled={isSubmitting}
           />
+          <button
+            type="submit"
+            disabled={isSubmitting || !input.trim()}
+            className={`px-5 py-3 rounded-xl font-semibold transition-colors ${
+              isSubmitting
+                ? 'bg-gray-300 dark:bg-gray-700 text-gray-600 dark:text-gray-300 cursor-not-allowed'
+                : 'bg-winter-600 text-white hover:bg-winter-700'
+            }`}
+          >
+            {isSubmitting ? 'Wird hinzugefügt…' : 'Hinzufügen'}
+          </button>
+        </form>
 
-          <div className="mt-4 flex items-center gap-4">
-            <button
-              onClick={handleSave}
-              disabled={isSaving}
-              className="px-6 py-3 bg-winter-600 text-white rounded-lg hover:bg-winter-700 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isSaving ? t('common.loading') : t('common.save')}
-            </button>
-
-            {saveStatus === 'success' && (
-              <span className="text-green-600 dark:text-green-400 font-medium">
-                ✓ {t('notes.saved')}
-              </span>
-            )}
-
-            {saveStatus === 'error' && (
-              <span className="text-red-600 dark:text-red-400 font-medium">
-                ✗ {t('notes.saveError')}
-              </span>
-            )}
-          </div>
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Heute</h2>
+          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+            <input
+              type="checkbox"
+              checked={autoTracking}
+              onChange={(event) => setAutoTracking(event.target.checked)}
+            />
+            Auto-Tracking aktiv
+          </label>
         </div>
+
+        <AggregatesBar aggregates={aggregates} />
+
+        <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
+          {notes.length === 0 ? (
+            <div className="text-sm text-gray-600 dark:text-gray-400 text-center py-10">Noch keine Smart Notes vorhanden.</div>
+          ) : (
+            notes.map((note) => <NoteCard key={note.id} note={note} />)
+          )}
+        </div>
+
+        {hasMore && (
+          <button
+            type="button"
+            onClick={handleLoadMore}
+            className="w-full py-3 rounded-xl border border-gray-200 dark:border-gray-700 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+            disabled={loadingMore}
+          >
+            {loadingMore ? 'Lädt…' : 'Mehr laden'}
+          </button>
+        )}
       </div>
     </div>
   );
 }
 
 export default NotesPage;
+

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -1,0 +1,48 @@
+import { SmartNote, Event } from '../types/events';
+
+export interface SummarizeInput {
+  raw: string;
+  recentNotes: SmartNote[];
+  candidates: Event[];
+}
+
+export async function summarizeAndValidate(
+  input: SummarizeInput
+): Promise<{ summary: string; events: Event[] }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 6000);
+
+  try {
+    const response = await fetch('/api/gemini', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      signal: controller.signal,
+      body: JSON.stringify({
+        systemPrompt:
+          "Du bist ein präziser Fitness-Assistent. Fasse die Eingabe in 1–2 Sätzen aktiv zusammen (ohne Emojis).\nNormalisiere Events exakt auf dieses Schema und liefere NUR JSON:\n{ 'summary':'...', 'events':[ ...Event-Objekte wie spezifiziert... ] }\nEinheiten konsistent (l→ml, Dezimalkomma zulassen), keine Halluzinationen, bei Unsicherheit confidence senken oder Feld weglassen. Sprache der summary = Sprache der Eingabe.",
+        payload: input,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Gemini request failed with status ${response.status}`);
+    }
+
+    const text = await response.text();
+    const parsed = JSON.parse(text);
+    return {
+      summary: parsed.summary ?? input.raw,
+      events: Array.isArray(parsed.events) ? parsed.events : [],
+    };
+  } catch (error) {
+    if ((error as Error).name === 'AbortError') {
+      throw new Error('Gemini timeout');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+

--- a/src/store/noteStore.ts
+++ b/src/store/noteStore.ts
@@ -1,0 +1,228 @@
+import Dexie, { Table } from 'dexie';
+import { SmartNote, WorkoutEvent } from '../types/events';
+
+const FALLBACK_KEY = 'smart_notes_fallback';
+
+class SmartNoteDexie extends Dexie {
+  smart_notes!: Table<SmartNote>;
+
+  constructor() {
+    super('winter_arc_smart_notes');
+    this.version(1).stores({
+      smart_notes: 'id, ts',
+    });
+  }
+}
+
+function isDexieAvailable() {
+  try {
+    return typeof indexedDB !== 'undefined';
+  } catch {
+    return false;
+  }
+}
+
+const db = isDexieAvailable()
+  ? new SmartNoteDexie()
+  : null;
+
+type NotesListener = () => void;
+
+const listeners = new Set<NotesListener>();
+
+function emit() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function readFallback(): SmartNote[] {
+  if (typeof localStorage === 'undefined') {
+    return [];
+  }
+  try {
+    const raw = localStorage.getItem(FALLBACK_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as SmartNote[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeFallback(notes: SmartNote[]) {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  try {
+    localStorage.setItem(FALLBACK_KEY, JSON.stringify(notes));
+  } catch (error) {
+    console.warn('Failed to persist smart notes fallback', error);
+  }
+}
+
+async function putNote(note: SmartNote): Promise<void> {
+  if (db) {
+    await db.smart_notes.put(note);
+    return;
+  }
+  const notes = readFallback();
+  const existingIndex = notes.findIndex((n) => n.id === note.id);
+  if (existingIndex >= 0) {
+    notes.splice(existingIndex, 1, note);
+  } else {
+    notes.unshift(note);
+  }
+  notes.sort((a, b) => b.ts - a.ts);
+  writeFallback(notes);
+}
+
+async function getNote(id: string): Promise<SmartNote | undefined> {
+  if (db) {
+    return db.smart_notes.get(id);
+  }
+  return readFallback().find((note) => note.id === id);
+}
+
+async function deleteNote(id: string): Promise<void> {
+  if (db) {
+    await db.smart_notes.delete(id);
+    return;
+  }
+  const notes = readFallback().filter((note) => note.id !== id);
+  writeFallback(notes);
+}
+
+async function fetchNotes(limit: number, cursor?: number): Promise<SmartNote[]> {
+  if (db) {
+    if (cursor) {
+      return db.smart_notes
+        .where('ts')
+        .below(cursor)
+        .reverse()
+        .limit(limit)
+        .toArray();
+    }
+    return db.smart_notes.orderBy('ts').reverse().limit(limit).toArray();
+  }
+  const notes = readFallback();
+  const filtered = cursor ? notes.filter((note) => note.ts < cursor) : notes;
+  return filtered.slice(0, limit);
+}
+
+function filterToday(notes: SmartNote[]): SmartNote[] {
+  const startOfDay = new Date();
+  startOfDay.setHours(0, 0, 0, 0);
+  const startTime = startOfDay.getTime();
+  return notes.filter((note) => note.ts >= startTime);
+}
+
+function sumEvents(notes: SmartNote[]) {
+  const aggregates = {
+    waterMl: 0,
+    proteinG: 0,
+    pushups: 0,
+    workoutsBySport: {} as Record<WorkoutEvent['sport'], number>,
+    isRestDay: false,
+    lastWeightKg: undefined as number | undefined,
+    lastBfpPercent: undefined as number | undefined,
+  };
+
+  for (const note of notes) {
+    if (note.pending) continue;
+    for (const event of note.events) {
+      if (event.confidence < 0.5) continue;
+      switch (event.kind) {
+        case 'drink':
+          aggregates.waterMl += event.volumeMl;
+          break;
+        case 'protein':
+          aggregates.proteinG += event.grams;
+          break;
+        case 'pushups':
+          aggregates.pushups += event.count;
+          break;
+        case 'workout': {
+          const current = aggregates.workoutsBySport[event.sport] ?? 0;
+          aggregates.workoutsBySport[event.sport] = current + 1;
+          break;
+        }
+        case 'rest':
+          aggregates.isRestDay = true;
+          break;
+        case 'weight':
+          aggregates.lastWeightKg = event.kg;
+          break;
+        case 'bfp':
+          aggregates.lastBfpPercent = event.percent;
+          break;
+        case 'food':
+          if (typeof event.proteinG === 'number') {
+            aggregates.proteinG += event.proteinG;
+          }
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  return aggregates;
+}
+
+async function getAllNotes(): Promise<SmartNote[]> {
+  if (db) {
+    return db.smart_notes.orderBy('ts').reverse().toArray();
+  }
+  return readFallback();
+}
+
+export const noteStore = {
+  async add(note: SmartNote) {
+    await putNote(note);
+    emit();
+  },
+  async update(id: string, patch: Partial<SmartNote>) {
+    const existing = await getNote(id);
+    if (!existing) return;
+    const updated: SmartNote = {
+      ...existing,
+      ...patch,
+    };
+    await putNote(updated);
+    emit();
+  },
+  async remove(id: string) {
+    await deleteNote(id);
+    emit();
+  },
+  async list({ cursor, limit = 20 }: { cursor?: number; limit?: number }) {
+    const results = await fetchNotes(limit + 1, cursor);
+    const notes = results.slice(0, limit);
+    const hasMore = results.length > limit;
+    const nextCursor = hasMore ? notes[notes.length - 1]?.ts : undefined;
+    return { notes, nextCursor, hasMore };
+  },
+  async getRecent(limit = 5) {
+    if (db) {
+      return db.smart_notes.orderBy('ts').reverse().limit(limit).toArray();
+    }
+    return readFallback().slice(0, limit);
+  },
+  async get(id: string) {
+    return getNote(id);
+  },
+  async todayAggregates() {
+    const notes = filterToday(await getAllNotes());
+    return sumEvents(notes);
+  },
+  subscribe(listener: NotesListener) {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+};
+
+export type NoteStore = typeof noteStore;
+

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,88 @@
+export type EventKind =
+  | 'drink'
+  | 'protein'
+  | 'pushups'
+  | 'workout'
+  | 'rest'
+  | 'weight'
+  | 'bfp'
+  | 'food';
+
+export interface BaseEvent {
+  id: string;
+  ts: number;
+  kind: EventKind;
+  confidence: number;
+  source: 'heuristic' | 'llm';
+}
+
+export interface DrinkEvent extends BaseEvent {
+  kind: 'drink';
+  volumeMl: number;
+  beverage: 'water' | 'protein' | 'coffee' | 'tea' | 'other';
+}
+
+export interface ProteinEvent extends BaseEvent {
+  kind: 'protein';
+  grams: number;
+  sourceLabel?: string;
+}
+
+export interface PushupEvent extends BaseEvent {
+  kind: 'pushups';
+  count: number;
+}
+
+export interface WorkoutEvent extends BaseEvent {
+  kind: 'workout';
+  sport: 'hiit_hyrox' | 'cardio' | 'gym' | 'swimming' | 'football' | 'other';
+  durationMin?: number;
+  intensity?: 'easy' | 'moderate' | 'hard';
+  notes?: string;
+}
+
+export interface RestEvent extends BaseEvent {
+  kind: 'rest';
+  reason?: string;
+}
+
+export interface WeightEvent extends BaseEvent {
+  kind: 'weight';
+  kg: number;
+}
+
+export interface BfpEvent extends BaseEvent {
+  kind: 'bfp';
+  percent: number;
+}
+
+export interface FoodEvent extends BaseEvent {
+  kind: 'food';
+  label: string;
+  calories?: number;
+  proteinG?: number;
+}
+
+export type Event =
+  | DrinkEvent
+  | ProteinEvent
+  | PushupEvent
+  | WorkoutEvent
+  | RestEvent
+  | WeightEvent
+  | BfpEvent
+  | FoodEvent;
+
+export interface SmartNote {
+  id: string;
+  ts: number;
+  raw: string;
+  summary: string;
+  events: Event[];
+  pending?: boolean;
+}
+
+export type SmartNoteInput = {
+  raw: string;
+};
+


### PR DESCRIPTION
## Summary
- replace the notes page with a quick-capture field, smart timeline cards, and auto-tracking toggle with event badges
- introduce typed smart note events, heuristic parsing, Gemini summarisation pipeline, and optimistic merging behaviour
- persist smart notes via Dexie/localStorage with daily aggregates and add unit tests for parsing, merging, and optimistic UI

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e4ed13553c83339c92200a81d91bd4