### PR TITLE
Allow configuring Gemini timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Der Client ruft `https://generativelanguage.googleapis.com/v1beta/models/gemini-
 
 Ein `401` oder `403` deutet auf einen fehlenden/ungültigen Schlüssel hin. Stelle sicher, dass der Key aktiv ist und in deiner `.env` verfügbar gemacht wird (`VITE_GEMINI_API_KEY=...`).
 
+Falls die Generierung bei dir regelmäßig durch ein Timeout abbricht, kannst du mit `VITE_GEMINI_TIMEOUT_MS` (Standard: `20000`) einen längeren Request-Timeout in Millisekunden konfigurieren.
+
 **Firebase Setup**:
 1. Gehe zu [Firebase Console](https://console.firebase.google.com/)
 2. Erstelle neues Projekt

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -8,6 +8,9 @@ export interface SummarizeInput {
 }
 
 const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
+const timeoutEnv = Number.parseInt(import.meta.env.VITE_GEMINI_TIMEOUT_MS ?? '', 10);
+const GEMINI_TIMEOUT_MS = Number.isFinite(timeoutEnv) && timeoutEnv > 0 ? timeoutEnv : 20000;
+
 const genAI = apiKey ? new GoogleGenerativeAI(apiKey) : null;
 
 function sanitizeNote(note: SmartNote) {
@@ -113,7 +116,9 @@ export async function summarizeAndValidate(
 
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutHandle = setTimeout(() => { reject(new Error('Gemini timeout')); }, 8000);
+      timeoutHandle = setTimeout(() => {
+        reject(new Error('Gemini timeout'));
+      }, GEMINI_TIMEOUT_MS);
     });
 
     const generationPromise = model.generateContent({


### PR DESCRIPTION
## Summary
- increase the Gemini summarization timeout to 20s and allow configuring it through `VITE_GEMINI_TIMEOUT_MS`
- document the new timeout override option in the README

## Testing
- npm run lint *(fails: existing lint and console warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5189452d08333a79f20167611328e