### PR TITLE
Fix tracking merge helpers

### DIFF
--- a/src/features/notes/trackingSync.ts
+++ b/src/features/notes/trackingSync.ts
@@ -82,7 +82,7 @@ function buildContributionFromEvent(event: Event, contribution: SmartTrackingCon
         duration: event.durationMin,
         intensity: event.intensity ? WORKOUT_INTENSITY_MAP[event.intensity] : undefined,
       };
-      if (isValidSportKey(sportKey)) { sports[sportKey] = mergeSportEntries(sports[sportKey], entry); }
+      sports[sportKey] = mergeSportEntries(sports[sportKey], entry);
       contribution.sports = sports;
       break;
     }

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -57,7 +57,7 @@ export function combineTrackingWithSmart(
     const weight = (() => {
       const value = manual?.weight?.value ?? smart?.weight?.value;
       const bodyFat = manual?.weight?.bodyFat ?? smart?.weight?.bodyFat;
-      const bmi = manual?.weight?.bmi;
+      const bmi = manual.weight?.bmi;
 
       if (value === undefined && bodyFat === undefined && bmi === undefined) {
         return undefined;

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -56,7 +56,7 @@ export function combineTrackingWithSmart(
 
     const weight = (() => {
       const value = manual?.weight?.value ?? smart?.weight?.value;
-      const bodyFat = manual?.weight?.bodyFat ?? smart?.weight?.bodyFat;
+      const bodyFat = manual.weight?.bodyFat ?? smart?.weight?.bodyFat;
       const bmi = manual.weight?.bmi;
 
       if (value === undefined && bodyFat === undefined && bmi === undefined) {

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -56,22 +56,22 @@ export function combineTrackingWithSmart(
 
     const weight = (() => {
       const value = manual?.weight?.value ?? smart?.weight?.value;
-      const bodyFat = manual.weight?.bodyFat ?? smart?.weight?.bodyFat;
-      const bmi = manual.weight?.bmi;
+      const bodyFat = manual?.weight?.bodyFat ?? smart?.weight?.bodyFat;
+      const bmi = manual?.weight?.bmi;
 
       if (value === undefined && bodyFat === undefined && bmi === undefined) {
         return undefined;
       }
 
       return {
-        ...(manual.weight ?? {}),
+        ...(manual?.weight ?? {}),
         value: value ?? manual?.weight?.value ?? 0,
         bodyFat,
         bmi,
       };
     })();
 
-    result[`${dateKey}`] = { date: manual?.date ?? dateKey, sports, water, protein, pushups, weight, completed: manual?.completed ?? false };
+    result[`${dateKey}`] = {
       date: manual?.date ?? dateKey,
       sports,
       water,

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -64,7 +64,7 @@ export function combineTrackingWithSmart(
       }
 
       return {
-        ...(manual?.weight ?? {}),
+        ...(manual.weight ?? {}),
         value: value ?? manual?.weight?.value ?? 0,
         bodyFat,
         bmi,


### PR DESCRIPTION
## Summary
- guard smart tracking weight merges against missing manual data and restore proper result object creation
- allow workout events to merge sport entries without referencing a missing validator

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5183dc4e08333b7f753bf02378c6b