### PR TITLE
Fix missing assets and stabilize tracking helpers

### DIFF
--- a/public/bg/dark/winter_arc_bg_dark.svg
+++ b/public/bg/dark/winter_arc_bg_dark.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="winterDarkGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#111827" />
+      <stop offset="50%" stop-color="#15213a" />
+      <stop offset="100%" stop-color="#0b1120" />
+    </linearGradient>
+    <radialGradient id="aurora" cx="70%" cy="30%" r="60%">
+      <stop offset="0%" stop-color="rgba(96, 165, 250, 0.65)" />
+      <stop offset="100%" stop-color="rgba(96, 165, 250, 0)" />
+    </radialGradient>
+    <radialGradient id="aurora2" cx="30%" cy="70%" r="55%">
+      <stop offset="0%" stop-color="rgba(129, 140, 248, 0.55)" />
+      <stop offset="100%" stop-color="rgba(129, 140, 248, 0)" />
+    </radialGradient>
+    <pattern id="snowDark" width="1" height="1" patternUnits="objectBoundingBox">
+      <circle cx="12" cy="14" r="2.2" fill="rgba(226, 232, 240, 0.35)" />
+      <circle cx="58" cy="32" r="1.4" fill="rgba(226, 232, 240, 0.25)" />
+      <circle cx="28" cy="68" r="1.6" fill="rgba(226, 232, 240, 0.2)" />
+      <circle cx="74" cy="52" r="1.1" fill="rgba(226, 232, 240, 0.18)" />
+    </pattern>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#winterDarkGradient)" />
+  <rect width="1920" height="1080" fill="url(#aurora)" />
+  <rect width="1920" height="1080" fill="url(#aurora2)" />
+  <g opacity="0.18" transform="skewX(-12)">
+    <rect x="-220" y="120" width="580" height="1100" rx="120" fill="#1e3a8a" />
+    <rect x="420" y="-220" width="540" height="1020" rx="140" fill="#2563eb" />
+    <rect x="1040" y="80" width="660" height="1100" rx="160" fill="#1d4ed8" />
+    <rect x="1580" y="-160" width="480" height="1020" rx="150" fill="#312e81" />
+  </g>
+  <g opacity="0.35">
+    <rect width="1920" height="1080" fill="url(#snowDark)" />
+  </g>
+</svg>

--- a/public/bg/light/winter_arc_bg_light.svg
+++ b/public/bg/light/winter_arc_bg_light.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="winterLightGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#eef5ff" />
+      <stop offset="45%" stop-color="#f8fbff" />
+      <stop offset="100%" stop-color="#d8ecff" />
+    </linearGradient>
+    <radialGradient id="winterGlow" cx="20%" cy="25%" r="65%">
+      <stop offset="0%" stop-color="rgba(255, 255, 255, 0.85)" />
+      <stop offset="100%" stop-color="rgba(255, 255, 255, 0)" />
+    </radialGradient>
+    <radialGradient id="winterGlow2" cx="80%" cy="75%" r="55%">
+      <stop offset="0%" stop-color="rgba(255, 255, 255, 0.55)" />
+      <stop offset="100%" stop-color="rgba(255, 255, 255, 0)" />
+    </radialGradient>
+    <pattern id="snow" x="0" y="0" width="1" height="1" patternUnits="objectBoundingBox">
+      <circle cx="10" cy="10" r="2" fill="rgba(255, 255, 255, 0.45)" />
+      <circle cx="60" cy="30" r="1.2" fill="rgba(255, 255, 255, 0.25)" />
+      <circle cx="30" cy="70" r="1.8" fill="rgba(255, 255, 255, 0.35)" />
+      <circle cx="80" cy="50" r="1" fill="rgba(255, 255, 255, 0.2)" />
+    </pattern>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#winterLightGradient)" />
+  <rect width="1920" height="1080" fill="url(#winterGlow)" />
+  <rect width="1920" height="1080" fill="url(#winterGlow2)" />
+  <g opacity="0.12" transform="skewX(-10)">
+    <rect x="-200" y="150" width="600" height="1100" rx="120" fill="#b3d8ff" />
+    <rect x="400" y="-200" width="520" height="1000" rx="140" fill="#c6e3ff" />
+    <rect x="980" y="100" width="640" height="1080" rx="160" fill="#cfe7ff" />
+    <rect x="1500" y="-180" width="480" height="980" rx="140" fill="#b9dcff" />
+  </g>
+  <g opacity="0.35">
+    <rect width="1920" height="1080" fill="url(#snow)" />
+  </g>
+</svg>

--- a/public/vite.svg
+++ b/public/vite.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 410 404">
+  <defs>
+    <linearGradient id="viteGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#41d1ff" />
+      <stop offset="45%" stop-color="#bd34fe" />
+      <stop offset="100%" stop-color="#f7a1ff" />
+    </linearGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="12" result="coloredBlur" />
+      <feMerge>
+        <feMergeNode in="coloredBlur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <path fill="#FFEA83" d="M255.153 37.938L50.745 212.923c-4.532 3.912-1.995 11.527 4.052 11.777l121.797 5.14c2.325.098 4.371 1.57 5.171 3.774l37.689 104.139c2.159 5.969 10.579 6.273 13.185.46l129.06-280.535c2.806-6.108-4.965-11.81-10.527-7.64L278.24 73.662a6.889 6.889 0 01-8.448.051l-9.827-7.03a6.888 6.888 0 00-8.462.051z"/>
+  <path filter="url(#glow)" fill="url(#viteGradient)" d="M392.378 25.017L215.08 361.265c-2.99 5.654-11.36 5.653-14.348-.002L7.622 25.017C4.048 18.238 9.485 10 17.08 10h375.84c7.594 0 13.032 8.238 9.457 15.017z"/>
+</svg>

--- a/src/components/WeekOverview.tsx
+++ b/src/components/WeekOverview.tsx
@@ -24,7 +24,9 @@ function WeekOverview() {
   const weekDays = Array.from({ length: 7 }, (_, i) => {
     const date = addDays(weekStart, i);
     const dateStr = format(date, 'yyyy-MM-dd');
-    const dayTracking = combinedTracking.hasOwnProperty(dateStr) ? combinedTracking[dateStr] : null;
+    const dayTracking = Object.prototype.hasOwnProperty.call(combinedTracking, dateStr)
+      ? combinedTracking[dateStr]
+      : null;
     const isToday = isSameDay(date, today);
     const isSelected = dateStr === activeDate;
 

--- a/src/features/notes/trackingSync.ts
+++ b/src/features/notes/trackingSync.ts
@@ -82,7 +82,7 @@ function buildContributionFromEvent(event: Event, contribution: SmartTrackingCon
         duration: event.durationMin,
         intensity: event.intensity ? WORKOUT_INTENSITY_MAP[event.intensity] : undefined,
       };
-      if (isValidSportKey(sportKey)) { sports[sportKey] = mergeSportEntries(sports[sportKey], entry); }
+      sports[sportKey] = mergeSportEntries(sports[sportKey], entry);
       contribution.sports = sports;
       break;
     }

--- a/src/hooks/useCombinedTracking.ts
+++ b/src/hooks/useCombinedTracking.ts
@@ -17,5 +17,5 @@ export function useCombinedDailyTracking(dateKey?: string) {
   if (!dateKey) {
     return undefined;
   }
-  return combined.hasOwnProperty(dateKey) ? combined[dateKey] : undefined;
+  return Object.prototype.hasOwnProperty.call(combined, dateKey) ? combined[dateKey] : undefined;
 }

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -56,22 +56,22 @@ export function combineTrackingWithSmart(
 
     const weight = (() => {
       const value = manual?.weight?.value ?? smart?.weight?.value;
-      const bodyFat = manual.weight?.bodyFat ?? smart?.weight?.bodyFat;
-      const bmi = manual.weight?.bmi;
+      const bodyFat = manual?.weight?.bodyFat ?? smart?.weight?.bodyFat;
+      const bmi = manual?.weight?.bmi;
 
       if (value === undefined && bodyFat === undefined && bmi === undefined) {
         return undefined;
       }
 
       return {
-        ...(manual.weight ?? {}),
+        ...(manual?.weight ?? {}),
         value: value ?? manual?.weight?.value ?? 0,
         bodyFat,
         bmi,
       };
     })();
 
-    result[`${dateKey}`] = { date: manual?.date ?? dateKey, sports, water, protein, pushups, weight, completed: manual?.completed ?? false };
+    result[`${dateKey}`] = {
       date: manual?.date ?? dateKey,
       sports,
       water,


### PR DESCRIPTION
## Summary
- add light and dark background SVGs and the missing Vite icon to stop asset 404s
- harden tracking combination logic to handle absent manual data safely
- clean up smart tracking merge utilities to satisfy lint rules

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e518ac6ccc833380f6371e0a05ed0c