### PR TITLE
Sanitize Firestore payloads before writes

### DIFF
--- a/src/components/WeekOverview.tsx
+++ b/src/components/WeekOverview.tsx
@@ -25,7 +25,7 @@ function WeekOverview() {
     const date = addDays(weekStart, i);
     const dateStr = format(date, 'yyyy-MM-dd');
     const dayTracking = Object.prototype.hasOwnProperty.call(combinedTracking, dateStr)
-      const dayTracking = Object.prototype.hasOwnProperty.call(combinedTracking, dateStr) ? combinedTracking[dateStr] : null;
+      ? combinedTracking[dateStr]
       : null;
     const isToday = isSameDay(date, today);
     const isSelected = dateStr === activeDate;

--- a/src/services/firestoreService.ts
+++ b/src/services/firestoreService.ts
@@ -3,15 +3,49 @@ import { db } from '../firebase/config';
 import type { User, DailyTracking, GroupMember, TrackingRecord } from '../types';
 import { countActiveSports } from '../utils/sports';
 
+type AnyRecord = Record<string, unknown>;
+
+function sanitizeForFirestore<T>(value: T): T {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeForFirestore(item)) as unknown as T;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as unknown as T;
+  }
+
+  if (typeof value === 'object') {
+    const sanitizedEntries = Object.entries(value as AnyRecord).reduce<AnyRecord>((acc, [key, entryValue]) => {
+      if (entryValue === undefined) {
+        return acc;
+      }
+
+      const sanitizedValue = sanitizeForFirestore(entryValue);
+
+      if (sanitizedValue !== undefined) {
+        acc[key] = sanitizedValue;
+      }
+
+      return acc;
+    }, {});
+
+    return sanitizedEntries as T;
+  }
+
+  return value;
+}
+
 // User operations
 export async function saveUser(userId: string, userData: Omit<User, 'id'>) {
   try {
     console.log('💾 Saving user data to Firestore...', { userId });
     const userRef = doc(db, 'users', userId);
     // Remove undefined fields to avoid Firestore error
-    const cleanedData = Object.fromEntries(
-      Object.entries(userData).filter(([_, value]) => value !== undefined)
-    );
+    const cleanedData = sanitizeForFirestore(userData);
     await setDoc(userRef, cleanedData);
     console.log('✅ User data saved successfully');
     return { success: true };
@@ -51,7 +85,8 @@ export async function updateUser(userId: string, updates: Partial<Omit<User, 'id
 export async function saveDailyTracking(userId: string, date: string, tracking: DailyTracking) {
   try {
     const trackingRef = doc(db, 'tracking', userId, 'days', date);
-    await setDoc(trackingRef, tracking);
+    const sanitizedTracking = sanitizeForFirestore(tracking);
+    await setDoc(trackingRef, sanitizedTracking);
     return { success: true };
   } catch (error) {
     console.error('Error saving tracking:', error);


### PR DESCRIPTION
## Summary
- add a reusable `sanitizeForFirestore` helper that deep clones objects while removing undefined values
- apply the sanitizer to user and daily tracking writes so Firestore never receives undefined payload entries
- repair a malformed ternary in `WeekOverview` uncovered by the stricter pre-commit checks

## Testing
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e5237916a08333849503e0e08666d2