### PR TITLE
Add image attachment support to smart notes

### DIFF
--- a/src/__tests__/NotesPage.test.tsx
+++ b/src/__tests__/NotesPage.test.tsx
@@ -57,24 +57,27 @@ vi.mock('../store/noteStore', () => ({ noteStore: noteStoreMock }));
 
 vi.mock('../features/notes/pipeline', () => {
   return {
-    processSmartNote: vi.fn(async (raw: string) => {
-      const note: SmartNote = {
-        id: `note-${Math.random().toString(16).slice(2)}`,
-        ts: Date.now(),
-        raw,
-        summary: raw,
-        events: [],
-        pending: true,
-      };
-      await noteStoreMock.add(note);
-      setTimeout(() => {
-        void noteStoreMock.update(note.id, {
-          summary: `Processed: ${raw}`,
-          pending: false,
-        });
-      }, 150);
-      return { noteId: note.id };
-    }),
+    processSmartNote: vi.fn(
+      async (raw: string, options?: { autoTracking?: boolean; attachments?: SmartNote['attachments'] }) => {
+        const note: SmartNote = {
+          id: `note-${Math.random().toString(16).slice(2)}`,
+          ts: Date.now(),
+          raw,
+          summary: raw,
+          events: [],
+          pending: true,
+          attachments: options?.attachments,
+        };
+        await noteStoreMock.add(note);
+        setTimeout(() => {
+          void noteStoreMock.update(note.id, {
+            summary: `Processed: ${raw}`,
+            pending: false,
+          });
+        }, 150);
+        return { noteId: note.id };
+      }
+    ),
     retrySmartNote: vi.fn(),
   };
 });

--- a/src/features/notes/pipeline.ts
+++ b/src/features/notes/pipeline.ts
@@ -121,7 +121,15 @@ function createOptimisticSummary(raw: string) {
   return `${raw.slice(0, 117)}...`;
 }
 
-export async function processSmartNote(rawInput: string, options: { autoTracking: boolean } = { autoTracking: true }) {
+type ProcessSmartNoteOptions = {
+  autoTracking: boolean;
+  attachments?: SmartNote['attachments'];
+};
+
+export async function processSmartNote(
+  rawInput: string,
+  options: ProcessSmartNoteOptions = { autoTracking: true }
+) {
   const raw = rawInput.trim();
   if (!raw) {
     throw new Error('Empty input');
@@ -129,6 +137,7 @@ export async function processSmartNote(rawInput: string, options: { autoTracking
 
   const ts = Date.now();
   const noteId = createEventId();
+  const attachments = options.attachments?.length ? options.attachments : undefined;
 
   if (!options.autoTracking) {
     const note: SmartNote = {
@@ -137,6 +146,7 @@ export async function processSmartNote(rawInput: string, options: { autoTracking
       raw,
       summary: raw,
       events: [],
+      attachments,
     };
     await noteStore.add(note);
     return { noteId };
@@ -152,6 +162,7 @@ export async function processSmartNote(rawInput: string, options: { autoTracking
     summary: createOptimisticSummary(raw),
     events: optimisticEvents,
     pending: true,
+    attachments,
   };
 
   await noteStore.add(optimisticNote);

--- a/src/pages/NotesPage.tsx
+++ b/src/pages/NotesPage.tsx
@@ -330,7 +330,7 @@ function NotesPage() {
                 type="file"
                 accept="image/*"
                 capture="environment"
-                onChange={handleAttachmentChange}
+                onChange={() => handleAttachmentChange(event)}
                 className="hidden"
                 multiple
               />

--- a/src/pages/NotesPage.tsx
+++ b/src/pages/NotesPage.tsx
@@ -1,7 +1,7 @@
-import { FormEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, FormEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { formatDistanceToNow } from 'date-fns';
 import { useTranslation } from '../hooks/useTranslation';
-import { SmartNote, Event } from '../types/events';
+import { SmartNote, Event, SmartNoteAttachment } from '../types/events';
 import { noteStore } from '../store/noteStore';
 import { processSmartNote, retrySmartNote } from '../features/notes/pipeline';
 
@@ -168,6 +168,18 @@ function NoteCard({ note }: { note: SmartNote }) {
         )}
       </div>
       <EventBadges events={note.events} />
+      {note.attachments && note.attachments.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-3">
+          {note.attachments.map((attachment) => (
+            <img
+              key={attachment.id}
+              src={attachment.url}
+              alt="Notizanhang"
+              className="h-20 w-20 object-cover rounded-xl border border-gray-200 dark:border-gray-700"
+            />
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -181,6 +193,55 @@ function NotesPage() {
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const limitRef = useRef(PAGE_SIZE);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [attachments, setAttachments] = useState<SmartNoteAttachment[]>([]);
+
+  const createAttachmentId = useCallback(() => {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      return crypto.randomUUID();
+    }
+    return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  }, []);
+
+  const handleAttachmentChange = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const files = event.target.files;
+      if (!files || files.length === 0) return;
+
+      const readers = Array.from(files).map(
+        (file) =>
+          new Promise<SmartNoteAttachment | null>((resolve) => {
+            const reader = new FileReader();
+            reader.onload = () => {
+              if (typeof reader.result === 'string') {
+                resolve({ id: createAttachmentId(), url: reader.result, type: 'image' });
+              } else {
+                resolve(null);
+              }
+            };
+            reader.onerror = () => {
+              console.error('Failed to read attachment file');
+              resolve(null);
+            };
+            reader.readAsDataURL(file);
+          })
+      );
+
+      const nextAttachments = (await Promise.all(readers)).filter(
+        (attachment): attachment is SmartNoteAttachment => Boolean(attachment)
+      );
+      if (nextAttachments.length) {
+        setAttachments((prev) => [...prev, ...nextAttachments]);
+      }
+
+      event.target.value = '';
+    },
+    [createAttachmentId]
+  );
+
+  const handleAttachmentRemove = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((attachment) => attachment.id !== id));
+  }, []);
 
   const loadNotes = useCallback(async (limit = limitRef.current) => {
     const { notes: fetched, hasMore: more } = await noteStore.list({ limit });
@@ -203,15 +264,16 @@ function NotesPage() {
       if (!input.trim()) return;
       setIsSubmitting(true);
       try {
-        await processSmartNote(input, { autoTracking });
+        await processSmartNote(input, { autoTracking, attachments: attachments.length ? attachments : undefined });
         setInput('');
+        setAttachments([]);
       } catch (error) {
         console.error('Failed to process note', error);
       } finally {
         setIsSubmitting(false);
       }
     },
-    [input, autoTracking]
+    [input, autoTracking, attachments]
   );
 
   const handleLoadMore = useCallback(async () => {
@@ -233,13 +295,54 @@ function NotesPage() {
 
       <div className="max-w-[700px] mx-auto px-4 pt-4 md:pt-6 pb-20 space-y-6">
         <form onSubmit={onSubmit} className="glass dark:glass-dark rounded-2xl p-5 flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
-          <input
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder="Kurz notieren…"
-            className="flex-1 px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-winter-500 outline-none"
-            disabled={isSubmitting}
-          />
+          <div className="flex-1 w-full">
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Kurz notieren…"
+              className="w-full px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-winter-500 outline-none"
+              disabled={isSubmitting}
+            />
+            {attachments.length > 0 ? (
+              <div className="mt-3 flex flex-wrap gap-3">
+                {attachments.map((attachment) => (
+                  <div key={attachment.id} className="relative">
+                    <img
+                      src={attachment.url}
+                      alt="Ausgewählter Anhang"
+                      className="h-20 w-20 object-cover rounded-xl border border-gray-200 dark:border-gray-700"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleAttachmentRemove(attachment.id)}
+                      className="absolute -top-2 -right-2 h-6 w-6 rounded-full bg-black/70 text-white text-xs flex items-center justify-center"
+                      aria-label="Anhang entfernen"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+            <div className="mt-3 flex flex-wrap gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                capture="environment"
+                onChange={handleAttachmentChange}
+                className="hidden"
+                multiple
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="px-4 py-2 rounded-xl border border-dashed border-winter-400 text-sm text-winter-600 hover:bg-winter-50 dark:border-winter-500/60 dark:text-winter-200 dark:hover:bg-winter-900/50"
+              >
+                📷 Foto aufnehmen oder wählen
+              </button>
+            </div>
+          </div>
           <button
             type="submit"
             disabled={isSubmitting || !input.trim()}

--- a/src/pages/NotesPage.tsx
+++ b/src/pages/NotesPage.tsx
@@ -314,7 +314,7 @@ function NotesPage() {
                     />
                     <button
                       type="button"
-                      onClick={() => handleAttachmentRemove(attachment.id)}
+                      onClick={() => { handleAttachmentRemove(attachment.id); }}
                       className="absolute -top-2 -right-2 h-6 w-6 rounded-full bg-black/70 text-white text-xs flex items-center justify-center"
                       aria-label="Anhang entfernen"
                     >

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -73,6 +73,12 @@ export type Event =
   | BfpEvent
   | FoodEvent;
 
+export type SmartNoteAttachment = {
+  id: string;
+  url: string;
+  type: 'image';
+};
+
 export interface SmartNote {
   id: string;
   ts: number;
@@ -80,6 +86,7 @@ export interface SmartNote {
   summary: string;
   events: Event[];
   pending?: boolean;
+  attachments?: SmartNoteAttachment[];
 }
 
 export type SmartNoteInput = {


### PR DESCRIPTION
## Summary
- add image attachment metadata to smart notes and ensure persistence through the note pipeline
- extend the notes page UI with image capture, preview, and removal controls for attachments
- adjust smart note processing flow and related tests to handle attachments

## Testing
- npm run test:unit -- src/__tests__/NotesPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e5235f44c08333aaaeb97865c4d9c7