### PR TITLE
Fix JSX syntax issues blocking build

### DIFF
--- a/src/components/ProteinTile.tsx
+++ b/src/components/ProteinTile.tsx
@@ -114,7 +114,9 @@ function ProteinTile() {
               pattern="[0-9]*"
               value={inputValue}
               onChange={(e) => { setInputValue(e.target.value); }}
-              onKeyDown={(e) => { if (e.key === 'Enter') saveProtein(); }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') saveProtein();
+              }}
               placeholder="g"
               className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none mb-4"
               autoFocus
@@ -138,17 +140,9 @@ function ProteinTile() {
               </button>
             </div>
           </div>
-        ) : (
-          <button
-            type="button"
-            onClick={() => { setShowInput(true); }}
-            className="w-full px-3 py-2 bg-orange-50 dark:bg-orange-900/20 text-orange-600 dark:text-orange-400 rounded-lg hover:bg-orange-100 dark:hover:bg-orange-900/30 transition-colors font-medium text-xs"
-          >
-            {t('tracking.addProtein')}
-          </button>
-        )}
-      </div>
-    </div>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/components/WaterTile.tsx
+++ b/src/components/WaterTile.tsx
@@ -89,7 +89,10 @@ function WaterTile() {
           </div>
           <button
             type="button"
-            onClick={() => { addWater(amount); }}
+            onClick={() => {
+              setExactValue(manualWater.toString());
+              setShowModal(true);
+            }}
             className="px-2 py-1.5 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 text-blue-600 dark:text-blue-400 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors font-medium text-xs"
           >
             ✏️ {t('tracking.edit')}

--- a/src/components/WeekOverview.tsx
+++ b/src/components/WeekOverview.tsx
@@ -30,7 +30,7 @@ function WeekOverview() {
     const date = addDays(weekStart, i);
     const dateStr = format(date, 'yyyy-MM-dd');
     const dayTracking = Object.prototype.hasOwnProperty.call(combinedTracking, dateStr)
-      const dayTracking = combinedTracking[dateStr] || null;
+      ? combinedTracking[dateStr] || null
       : null;
     const isToday = isSameDay(date, today);
     const isSelected = dateStr === activeDate;

--- a/src/components/WeightTile.tsx
+++ b/src/components/WeightTile.tsx
@@ -331,15 +331,8 @@ function WeightTile() {
               </button>
             </div>
           </div>
-        ) : (
-          <button
-            onClick={() => { setShowInput(true); }}
-            className="w-full px-3 py-2 text-sm bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400 rounded-lg hover:bg-purple-100 dark:hover:bg-purple-900/30 transition-colors font-medium"
-          >
-            {t('tracking.addWeight')}
-          </button>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -35,12 +35,12 @@ function analyzeTrackingData(tracking: Record<string, DailyTracking>): UserTrack
     0
   );
 
-  const waterEntries = Object.values(tracking).filter(day => day.water > 0);
+  const waterEntries = Object.values(tracking).filter((day) => day.water > 0);
   const avgWater = waterEntries.length > 0
     ? waterEntries.reduce((sum, day) => sum + day.water, 0) / waterEntries.length
     : 0;
 
-  const proteinEntries = Object.values(tracking).filter(day => day.protein > 0);
+  const proteinEntries = Object.values(tracking).filter((day) => day.protein > 0);
   const avgProtein = proteinEntries.length > 0
     ? proteinEntries.reduce((sum, day) => sum + day.protein, 0) / proteinEntries.length
     : 0;
@@ -56,7 +56,7 @@ function analyzeTrackingData(tracking: Record<string, DailyTracking>): UserTrack
   const recentWeight = weightEntries.length > 0 ? weightEntries[0][1].weight?.value : undefined;
   const lastWorkoutDate = trackingDates.length > 0 ? trackingDates[trackingDates.length - 1] : undefined;
   const todayEntry = Object.prototype.hasOwnProperty.call(tracking, today)
-    const todayEntry = Object.prototype.hasOwnProperty.call(tracking, today) && typeof today === 'string' ? tracking[today] : undefined;
+    ? tracking[today]
     : undefined;
   const completedToday = todayEntry?.completed || false;
 
@@ -81,7 +81,7 @@ export async function generateDailyMotivation(
   try {
     // Nur Tracking-Daten der letzten 7 Tage verwenden
     const today = new Date();
-    const last7Days = Array.from({ length: 7 }).map((_, i) => {
+    const last7Days = Array.from({ length: 7 }, (_, i) => {
       const d = new Date(today);
       d.setDate(today.getDate() - i);
       return d.toISOString().split('T')[0];
@@ -105,7 +105,7 @@ export async function generateDailyMotivation(
     const stats = analyzeTrackingData(trackingLast7);
     const todayKey = now.toISOString().split('T')[0];
     const todayTrackingEntry = Object.prototype.hasOwnProperty.call(trackingLast7, todayKey)
-      const todayTrackingEntry = todayKey in trackingLast7 ? trackingLast7[todayKey] : undefined;
+      ? trackingLast7[todayKey]
       : undefined;
     const todayReps = todayTrackingEntry?.pushups?.workout?.reps;
 


### PR DESCRIPTION
## Summary
- fix incorrect JSX ternaries in tracking tiles and ensure modals only render when toggled
- correct weekly overview tracking lookup and ai service helpers for proper type checking
- adjust water edit button to open modal with current value

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e53374bea0833384f3a4c60fe41247