### PR TITLE
Fix syntax errors in tracking views

### DIFF
--- a/src/components/WeekOverview.tsx
+++ b/src/components/WeekOverview.tsx
@@ -30,7 +30,7 @@ function WeekOverview() {
     const date = addDays(weekStart, i);
     const dateStr = format(date, 'yyyy-MM-dd');
     const dayTracking = Object.prototype.hasOwnProperty.call(combinedTracking, dateStr)
-      const dayTracking = Object.prototype.hasOwnProperty.call(combinedTracking, dateStr) ? combinedTracking[dateStr] : undefined;
+      ? combinedTracking[dateStr]
       : undefined;
     const isToday = isSameDay(date, today);
     const isSelected = dateStr === activeDate;

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -56,7 +56,7 @@ function analyzeTrackingData(tracking: Record<string, DailyTracking>): UserTrack
   const recentWeight = weightEntries.length > 0 ? weightEntries[0][1].weight?.value : undefined;
   const lastWorkoutDate = trackingDates.length > 0 ? trackingDates[trackingDates.length - 1] : undefined;
   const todayEntry = Object.prototype.hasOwnProperty.call(tracking, today)
-    const todayEntry = tracking.hasOwnProperty(today) ? tracking[today] : undefined;
+    ? tracking[today]
     : undefined;
   const completedToday = todayEntry?.completed || false;
 
@@ -105,7 +105,7 @@ export async function generateDailyMotivation(
     const stats = analyzeTrackingData(trackingLast7);
     const todayKey = now.toISOString().split('T')[0];
     const todayTrackingEntry = Object.prototype.hasOwnProperty.call(trackingLast7, todayKey)
-      ? (Object.prototype.toString.call(trackingLast7) === '[object Object]' ? trackingLast7[todayKey] : undefined)
+      ? trackingLast7[todayKey]
       : undefined;
     const todayReps = todayTrackingEntry?.pushups?.workout?.reps;
 


### PR DESCRIPTION
## Summary
- fix the conditional lookup for daily tracking data in the week overview component
- correct the AI service's handling of today's tracking entry to avoid malformed syntax

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54134cb74833391affc245aacd8cc