### PR TITLE
Fix leaderboard progress when no tracking data is available

### DIFF
--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -126,9 +126,13 @@ function LeaderboardPage() {
   };
 
   const calculateDayProgress = (dateStr: string) => {
-    const dayTracking = combinedTracking[dateStr];
     const totalTasksForProgress = enabledActivities.length + 1; // +1 for weight
     const pointsPerTask = 100 / totalTasksForProgress;
+
+    const dayTracking = combinedTracking[dateStr];
+    if (!dayTracking) {
+      return 0;
+    }
 
     let progress = 0;
     if (enabledActivities.includes('pushups') && (dayTracking.pushups?.total || 0) > 0) {


### PR DESCRIPTION
## Summary
- guard the leaderboard progress calculation against missing tracking entries so the UI no longer crashes when data is absent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5467c4898833388cc7166261875f7