### PR TITLE
Refactor settings page layout to glass tokens

### DIFF
--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -131,6 +131,10 @@ export const translations = {
     settings: {
       title: 'Einstellungen',
       subtitle: 'Passe dein Profil an',
+      quickSettings: 'Schnelleinstellungen',
+      quickSettingsDesc: 'Passe Wetter, Aktivitäten und Erinnerungen für deinen Tag an.',
+      profileSettingsDesc: 'Aktualisiere persönliche Daten und teile Infos mit deiner Gruppe.',
+      accountSettingsDesc: 'Verwalte Kontoaktionen, Rechtliches und Entwickler-Tools.',
       weatherCity: 'Wetter-Stadt',
       weatherCityDesc: 'Stadt für Wetterdaten auswählen',
       profile: 'Profil',
@@ -377,6 +381,10 @@ export const translations = {
     settings: {
       title: 'Settings',
       subtitle: 'Customize your profile',
+      quickSettings: 'Quick actions',
+      quickSettingsDesc: 'Fine-tune weather, activities, and reminders for your day.',
+      profileSettingsDesc: 'Update personal data and sharing preferences for your group.',
+      accountSettingsDesc: 'Manage account actions, legal info, and developer tools.',
       weatherCity: 'Weather City',
       weatherCityDesc: 'Select city for weather data',
       profile: 'Profile',


### PR DESCRIPTION
## Summary
- restyle the Settings page to use the dashboard container layout and shared glass card tokens
- refresh toggles, forms, and buttons with white-on-glass typography and mobile friendly spacing via tabbed sections
- extend settings translations with labels for the new quick settings, profile, and account tabs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5476055508333b17701772d29876c