### PR TITLE
Persist smart notes to Firestore

### DIFF
--- a/src/pages/NotesPage.tsx
+++ b/src/pages/NotesPage.tsx
@@ -3,6 +3,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { useTranslation } from '../hooks/useTranslation';
 import { SmartNote, Event, SmartNoteAttachment } from '../types/events';
 import { noteStore } from '../store/noteStore';
+import { useStore } from '../store/useStore';
 import { processSmartNote, retrySmartNote } from '../features/notes/pipeline';
 import { glassCardClasses, glassCardHoverClasses, designTokens } from '../theme/tokens';
 
@@ -259,6 +260,13 @@ function NotesPage() {
     });
     return unsubscribe;
   }, [loadNotes]);
+
+  const user = useStore((state) => state.user);
+
+  useEffect(() => {
+    if (!user) return;
+    void noteStore.syncFromRemote();
+  }, [user]);
 
   const onSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {

--- a/src/services/smartNoteService.ts
+++ b/src/services/smartNoteService.ts
@@ -189,7 +189,7 @@ export async function deleteSmartNote(userId: string, note: SmartNote): Promise<
     await Promise.allSettled(
       note.attachments
         .filter((attachment) => Boolean(attachment.storagePath))
-        .map((attachment) => deleteObject(ref(storage, attachment.storagePath!)))
+        .map((attachment) => deleteObject(ref(storage, attachment.storagePath)))
     );
   }
 }

--- a/src/services/smartNoteService.ts
+++ b/src/services/smartNoteService.ts
@@ -44,7 +44,7 @@ function sanitizeForFirestore<T>(value: T): T {
       }
 
       if (typeof key === 'string' && key.trim() !== '') {
-        acc[key] = sanitizeForFirestore(entryValue);
+        if (isValidKey(key)) { acc[key] = sanitizeForFirestore(entryValue); }
       }
       return acc;
     }, {});

--- a/src/services/smartNoteService.ts
+++ b/src/services/smartNoteService.ts
@@ -1,0 +1,242 @@
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  setDoc,
+  where,
+  type QueryConstraint,
+} from 'firebase/firestore';
+import { deleteObject, getDownloadURL, ref, uploadBytes } from 'firebase/storage';
+import type { Firestore } from 'firebase/firestore';
+import type { FirebaseStorage } from 'firebase/storage';
+import type { SmartNote, SmartNoteAttachment } from '../types/events';
+
+const COLLECTION_KEY = 'smartNotes';
+
+type AnyRecord = Record<string, unknown>;
+
+type FetchOptions = {
+  limit?: number;
+  cursor?: number;
+};
+
+function sanitizeForFirestore<T>(value: T): T {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeForFirestore(item)) as unknown as T;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as unknown as T;
+  }
+
+  if (typeof value === 'object') {
+    const sanitizedEntries = Object.entries(value as AnyRecord).reduce<AnyRecord>((acc, [key, entryValue]) => {
+      if (entryValue === undefined) {
+        return acc;
+      }
+
+      if (typeof key === 'string' && key.trim() !== '') {
+        acc[key] = sanitizeForFirestore(entryValue);
+      }
+      return acc;
+    }, {});
+
+    return sanitizedEntries as T;
+  }
+
+  return value;
+}
+
+function isDataUrl(url: string): boolean {
+  return url.startsWith('data:');
+}
+
+let cachedDb: Firestore | null | undefined;
+let cachedStorage: FirebaseStorage | null | undefined;
+
+async function getFirestoreInstance(): Promise<Firestore | null> {
+  if (cachedDb !== undefined) {
+    return cachedDb;
+  }
+
+  if (typeof window === 'undefined') {
+    cachedDb = null;
+    return cachedDb;
+  }
+
+  try {
+    const module = await import('../firebase/config');
+    cachedDb = module.db;
+    return cachedDb;
+  } catch (error) {
+    console.warn('Firestore unavailable, skipping smart note persistence.', error);
+    cachedDb = null;
+    return cachedDb;
+  }
+}
+
+async function getStorageInstance(): Promise<FirebaseStorage | null> {
+  if (cachedStorage !== undefined) {
+    return cachedStorage;
+  }
+
+  if (typeof window === 'undefined') {
+    cachedStorage = null;
+    return cachedStorage;
+  }
+
+  try {
+    const module = await import('../firebase/config');
+    cachedStorage = module.storage;
+    return cachedStorage;
+  } catch (error) {
+    console.warn('Firebase storage unavailable, skipping attachment upload.', error);
+    cachedStorage = null;
+    return cachedStorage;
+  }
+}
+
+async function ensureAttachmentUploaded(
+  storage: FirebaseStorage,
+  userId: string,
+  noteId: string,
+  attachment: SmartNoteAttachment
+): Promise<SmartNoteAttachment> {
+  if (!isDataUrl(attachment.url) && attachment.storagePath) {
+    return attachment;
+  }
+
+  if (!isDataUrl(attachment.url) && !attachment.storagePath) {
+    // Attachment is already remote but missing storage metadata
+    return attachment;
+  }
+
+  const response = await fetch(attachment.url);
+  const blob = await response.blob();
+  const mime = blob.type || 'image/jpeg';
+  const extension = mime.split('/')[1] || 'jpg';
+  const storagePath = `smart-notes/${userId}/${noteId}/${attachment.id}.${extension}`;
+  const storageRef = ref(storage, storagePath);
+
+  await uploadBytes(storageRef, blob, {
+    contentType: mime,
+    cacheControl: 'public,max-age=31536000',
+  });
+
+  const downloadURL = await getDownloadURL(storageRef);
+
+  return {
+    ...attachment,
+    url: downloadURL,
+    storagePath,
+  };
+}
+
+export async function upsertSmartNote(userId: string, note: SmartNote): Promise<SmartNote> {
+  const firestore = await getFirestoreInstance();
+  if (!firestore) {
+    return note;
+  }
+
+  let attachments = note.attachments;
+
+  if (attachments && attachments.some((attachment) => attachment.url.startsWith('data:') || !attachment.storagePath)) {
+    const storage = await getStorageInstance();
+    if (!storage) {
+      console.warn('Skipping smart note upload because storage is unavailable.');
+      return note;
+    }
+
+    attachments = await Promise.all(
+      attachments.map((attachment) => ensureAttachmentUploaded(storage, userId, note.id, attachment))
+    );
+  }
+
+  const payload: SmartNote = {
+    ...note,
+    attachments,
+  };
+
+  const docRef = doc(firestore, 'users', userId, COLLECTION_KEY, note.id);
+  await setDoc(docRef, sanitizeForFirestore(payload), { merge: true });
+
+  return payload;
+}
+
+export async function deleteSmartNote(userId: string, note: SmartNote): Promise<void> {
+  const firestore = await getFirestoreInstance();
+  if (!firestore) {
+    return;
+  }
+
+  const docRef = doc(firestore, 'users', userId, COLLECTION_KEY, note.id);
+  await deleteDoc(docRef);
+
+  if (note.attachments && note.attachments.length > 0) {
+    const storage = await getStorageInstance();
+    if (!storage) {
+      return;
+    }
+
+    await Promise.allSettled(
+      note.attachments
+        .filter((attachment) => Boolean(attachment.storagePath))
+        .map((attachment) => deleteObject(ref(storage, attachment.storagePath!)))
+    );
+  }
+}
+
+export async function fetchSmartNotes(userId: string, options: FetchOptions = {}): Promise<SmartNote[]> {
+  const firestore = await getFirestoreInstance();
+  if (!firestore) {
+    return [];
+  }
+
+  const { limit: limitValue, cursor } = options;
+  const collectionRef = collection(firestore, 'users', userId, COLLECTION_KEY);
+  const constraints: QueryConstraint[] = [orderBy('ts', 'desc')];
+
+  if (typeof cursor === 'number') {
+    constraints.push(where('ts', '<', cursor));
+  }
+
+  if (typeof limitValue === 'number' && limitValue > 0) {
+    constraints.push(limit(limitValue));
+  }
+
+  const snapshot = await getDocs(query(collectionRef, ...constraints));
+
+  return snapshot.docs.map((docSnapshot) => {
+    const data = docSnapshot.data() as SmartNote;
+    return {
+      ...data,
+      id: docSnapshot.id,
+    };
+  });
+}
+
+export async function fetchAllSmartNotes(userId: string): Promise<SmartNote[]> {
+  const firestore = await getFirestoreInstance();
+  if (!firestore) {
+    return [];
+  }
+
+  const collectionRef = collection(firestore, 'users', userId, COLLECTION_KEY);
+  const snapshot = await getDocs(query(collectionRef, orderBy('ts', 'desc')));
+
+  return snapshot.docs.map((docSnapshot) => {
+    const data = docSnapshot.data() as SmartNote;
+    return {
+      ...data,
+      id: docSnapshot.id,
+    };
+  });
+}

--- a/src/store/noteStore.ts
+++ b/src/store/noteStore.ts
@@ -1,4 +1,6 @@
 import Dexie, { Table } from 'dexie';
+import type { Auth } from 'firebase/auth';
+import { deleteSmartNote as deleteRemoteSmartNote, fetchAllSmartNotes, upsertSmartNote } from '../services/smartNoteService';
 import { SmartNote, WorkoutEvent } from '../types/events';
 
 const FALLBACK_KEY = 'smart_notes_fallback';
@@ -110,6 +112,69 @@ async function fetchNotes(limit: number, cursor?: number): Promise<SmartNote[]> 
   return filtered.slice(0, limit);
 }
 
+let cachedAuth: Auth | null | undefined;
+
+async function getFirebaseAuth(): Promise<Auth | null> {
+  if (cachedAuth !== undefined) {
+    return cachedAuth;
+  }
+
+  if (typeof window === 'undefined') {
+    cachedAuth = null;
+    return cachedAuth;
+  }
+
+  try {
+    const module = await import('../firebase/config');
+    cachedAuth = module.auth;
+    return cachedAuth;
+  } catch (error) {
+    console.warn('Firebase auth unavailable, skipping remote persistence.', error);
+    cachedAuth = null;
+    return cachedAuth;
+  }
+}
+
+function hasPendingAttachmentUpload(note: SmartNote): boolean {
+  return (note.attachments ?? []).some((attachment) => attachment.url.startsWith('data:') || !attachment.storagePath);
+}
+
+async function persistRemote(note: SmartNote): Promise<void> {
+  const authInstance = await getFirebaseAuth();
+  const userId = authInstance?.currentUser?.uid;
+  if (!userId) {
+    console.warn('Skipping remote smart note persistence (no authenticated user).');
+    return;
+  }
+
+  try {
+    const saved = await upsertSmartNote(userId, note);
+    if (hasPendingAttachmentUpload(note)) {
+      await putNote(saved);
+      emit();
+    }
+  } catch (error) {
+    console.warn('Failed to persist smart note remotely', error);
+  }
+}
+
+async function removeRemote(note: SmartNote | undefined): Promise<void> {
+  if (!note) return;
+
+  const authInstance = await getFirebaseAuth();
+  const userId = authInstance?.currentUser?.uid;
+  if (!userId) {
+    console.warn('Skipping remote smart note removal (no authenticated user).');
+    return;
+  }
+
+  try {
+    await deleteRemoteSmartNote(userId, note);
+  } catch (error) {
+    console.warn('Failed to delete smart note remotely', error);
+  }
+}
+
 function filterToday(notes: SmartNote[]): SmartNote[] {
   const startOfDay = new Date();
   startOfDay.setHours(0, 0, 0, 0);
@@ -181,6 +246,7 @@ export const noteStore = {
   async add(note: SmartNote) {
     await putNote(note);
     emit();
+    void persistRemote(note);
   },
   async update(id: string, patch: Partial<SmartNote>) {
     const existing = await getNote(id);
@@ -191,10 +257,13 @@ export const noteStore = {
     };
     await putNote(updated);
     emit();
+    void persistRemote(updated);
   },
   async remove(id: string) {
+    const existing = await getNote(id);
     await deleteNote(id);
     emit();
+    void removeRemote(existing);
   },
   async list({ cursor, limit = 20 }: { cursor?: number; limit?: number }) {
     const results = await fetchNotes(limit + 1, cursor);
@@ -218,6 +287,35 @@ export const noteStore = {
   async todayAggregates() {
     const notes = filterToday(await getAllNotes());
     return sumEvents(notes);
+  },
+  async syncFromRemote() {
+    const authInstance = await getFirebaseAuth();
+    const userId = authInstance?.currentUser?.uid;
+    if (!userId) {
+      return;
+    }
+
+    try {
+      const remoteNotes = await fetchAllSmartNotes(userId);
+      const remoteIds = new Set(remoteNotes.map((note) => note.id));
+
+      for (const note of remoteNotes) {
+        await putNote(note);
+      }
+
+      const localNotes = await getAllNotes();
+      await Promise.all(
+        localNotes
+          .filter((note) => !remoteIds.has(note.id) && !note.pending)
+          .map(async (note) => {
+            await deleteNote(note.id);
+          })
+      );
+
+      emit();
+    } catch (error) {
+      console.warn('Failed to sync smart notes from Firestore', error);
+    }
   },
   subscribe(listener: NotesListener) {
     listeners.add(listener);

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -77,6 +77,7 @@ export type SmartNoteAttachment = {
   id: string;
   url: string;
   type: 'image';
+  storagePath?: string;
 };
 
 export interface SmartNote {


### PR DESCRIPTION
## Summary
- add a smart note service that lazily loads Firebase, uploads attachments to Storage, and stores notes in Firestore
- extend the note store to upsert/delete remote notes, sync from Firestore, and avoid blocking tests when Firebase isn’t configured
- trigger a remote sync once a user is present on the notes page and persist attachment storage metadata

## Testing
- npm run lint
- npm run format
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e54f5888b48333917b6337b9ef911b