### PR TITLE
Fix TypeScript build errors in onboarding and settings pages

### DIFF
--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -11,6 +11,10 @@ interface OnboardingPageProps {
 
 function OnboardingPage({ birthdayOnly = false }: OnboardingPageProps) {
   const { t } = useTranslation();
+  const user = useStore((state) => state.user);
+  const setUser = useStore((state) => state.setUser);
+  const setIsOnboarded = useStore((state) => state.setIsOnboarded);
+
   const [step, setStep] = useState(1);
   const [language, setLanguage] = useState<Language>('de');
   const [nickname, setNickname] = useState('');
@@ -24,10 +28,6 @@ function OnboardingPage({ birthdayOnly = false }: OnboardingPageProps) {
   const [maxPushups, setMaxPushups] = useState('');
   const [enabledActivities, setEnabledActivities] = useState<Activity[]>(['pushups', 'sports', 'water', 'protein']);
   const [birthday, setBirthday] = useState('');
-
-  const user = useStore((state) => state.user);
-  const setUser = useStore((state) => state.setUser);
-  const setIsOnboarded = useStore((state) => state.setIsOnboarded);
 
   const totalSteps = birthdayOnly ? 1 : 9;
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -749,7 +749,7 @@ function SettingsPage() {
                             ref={profilePictureInputRef}
                             type="file"
                             accept="image/*"
-                            onChange={() => { void handleProfilePictureFileChange(); }}
+                            onChange={(event) => { void handleProfilePictureFileChange(event); }}
                             className="hidden"
                           />
                         </div>


### PR DESCRIPTION
## Summary
- initialize Zustand user state before dependent React state in `OnboardingPage`
- pass the file input change event to `handleProfilePictureFileChange` in `SettingsPage`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e57263bbe08333a4aea7fbc918bfea