### PR TITLE
Fix auto tracking flag assignment

### DIFF
--- a/src/features/notes/pipeline.ts
+++ b/src/features/notes/pipeline.ts
@@ -212,7 +212,7 @@ export async function updateSmartNote(noteId: string, rawInput: string) {
   }
 
   const autoTrackingEnabled =
-    const autoTrackingEnabled = existing.pending === true || existing.summary !== existing.raw || (existing.events?.length > 0);
+    existing.pending === true || existing.summary !== existing.raw || (existing.events?.length > 0);
 
   if (!autoTrackingEnabled) {
     await noteStore.update(noteId, {

--- a/src/features/notes/pipeline.ts
+++ b/src/features/notes/pipeline.ts
@@ -212,7 +212,7 @@ export async function updateSmartNote(noteId: string, rawInput: string) {
   }
 
   const autoTrackingEnabled =
-    existing.pending === true || existing.summary !== existing.raw || (existing.events?.length > 0);
+    existing.pending === true || existing.summary !== existing.raw || (existing.events.length > 0);
 
   if (!autoTrackingEnabled) {
     await noteStore.update(noteId, {


### PR DESCRIPTION
## Summary
- correct the auto-tracking flag assignment in `updateSmartNote` to resolve the TypeScript build failure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e581fe0c9483338ecc2a7baf5f133e