### PR TITLE
Adjust weekday circle radius to avoid clipping

### DIFF
--- a/src/components/dashboard/WeekDayCircle.tsx
+++ b/src/components/dashboard/WeekDayCircle.tsx
@@ -11,7 +11,8 @@ interface WeekDayCircleProps {
   onClick: () => void;
 }
 
-const CIRCUMFERENCE = 2 * Math.PI * 22;
+const PROGRESS_RADIUS = 21;
+const CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RADIUS;
 
 function getProgressStroke(percent: number): string {
   if (percent >= 100) {
@@ -63,7 +64,7 @@ function WeekDayCircleComponent({
           <circle
             cx="24"
             cy="24"
-            r="22"
+            r={PROGRESS_RADIUS}
             fill="none"
             className="stroke-white/10"
             strokeWidth="4"
@@ -71,7 +72,7 @@ function WeekDayCircleComponent({
           <circle
             cx="24"
             cy="24"
-            r="22"
+            r={PROGRESS_RADIUS}
             fill="none"
             className={`${progressStroke} transition-all duration-300 ease-out`}
             strokeWidth="4"


### PR DESCRIPTION
## Summary
- reduce the weekday progress circle radius so its stroke remains within the SVG viewBox
- derive the circumference from a shared radius constant for consistent stroke calculations

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5805b199c833396b1fe0ce66dca56