### PR TITLE
Add weight tracking ratio to progress calculations

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ export type Gender = 'male' | 'female' | 'diverse';
 
 export type Language = 'de' | 'en';
 
-export type Activity = 'pushups' | 'sports' | 'water' | 'protein';
+export type Activity = 'pushups' | 'sports' | 'water' | 'protein' | 'weight';
 
 export type WorkoutStatus = 'pass' | 'hold' | 'fail';
 


### PR DESCRIPTION
## Summary
- include weight logging in day completion scoring with normalized weights and flags
- update the progress utility tests and streak logic to cover the new weight ratio
- extend the activity type list to support enabling weight tracking

## Testing
- npm test -- --runTestsByPath src/__tests__/progressUtils.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5805d609c83338959325a3f985231