### PR TITLE
fix: apply tracked styling to weight tile

### DIFF
--- a/src/components/WeightTile.tsx
+++ b/src/components/WeightTile.tsx
@@ -4,7 +4,7 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'rec
 import { useStore } from '../store/useStore';
 import { calculateBMI } from '../utils/calculations';
 import { useTranslation } from '../hooks/useTranslation';
-import { glassCardClasses, designTokens } from '../theme/tokens';
+import { getTileClasses, designTokens } from '../theme/tokens';
 import { useCombinedTracking, useCombinedDailyTracking } from '../hooks/useCombinedTracking';
 
 function WeightTile() {
@@ -127,9 +127,10 @@ function WeightTile() {
 
   const latestWeight = combinedDaily?.weight?.value ?? activeTracking?.weight?.value ?? user?.weight ?? 0;
   const latestBMI = activeTracking?.weight?.bmi ?? combinedDaily?.weight?.bmi;
+  const isTracked = Boolean(combinedDaily?.weight?.value ?? activeTracking?.weight?.value);
 
   return (
-    <div className={`${glassCardClasses} ${designTokens.padding.compact} text-white`}>
+    <div className={`${getTileClasses(isTracked)} ${designTokens.padding.compact} text-white`}>
       <div className="flex items-center gap-2 mb-2">
         <div className="text-xl">⚖️</div>
         <div>


### PR DESCRIPTION
## Summary
- import the shared getTileClasses helper inside the weight tile
- derive whether the weight tile has tracked data and feed it into the helper
- apply the helper so the tracked glow and opacity states are consistent

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5806044d88333a60951fa5de4e668