### PR TITLE
Add training load tile to dashboard

### DIFF
--- a/src/__tests__/TrainingLoadTile.test.tsx
+++ b/src/__tests__/TrainingLoadTile.test.tsx
@@ -1,0 +1,98 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import TrainingLoadTile from '../components/TrainingLoadTile';
+import { useStore } from '../store/useStore';
+import type { SportTracking } from '../types';
+
+const originalSelectedDate = useStore.getState().selectedDate;
+
+const baseSports: SportTracking = {
+  hiit: { active: false },
+  cardio: { active: false },
+  gym: { active: false },
+  schwimmen: { active: false },
+  soccer: { active: false },
+  rest: { active: false },
+};
+
+describe('TrainingLoadTile', () => {
+beforeEach(async () => {
+  await act(async () => {
+    useStore.setState({
+      user: {
+        id: 'training-load-user',
+        language: 'en',
+        nickname: 'Loady',
+        gender: 'male',
+        height: 180,
+        weight: 80,
+        hydrationGoalLiters: 2,
+        proteinGoalGrams: 120,
+        maxPushups: 30,
+        groupCode: 'grp',
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        pushupState: { baseReps: 10, sets: 3, restTime: 60 },
+        enabledActivities: ['pushups', 'sports'],
+      },
+      selectedDate: '2024-01-12',
+      tracking: {
+        '2024-01-12': {
+          date: '2024-01-12',
+          sports: {
+            ...baseSports,
+            cardio: { active: true, duration: 60, intensity: 6 },
+          },
+          pushups: {
+            total: 50,
+          },
+          water: 0,
+          protein: 0,
+          completed: false,
+          recovery: {
+            sleepQuality: 8,
+            recovery: 7,
+            illness: false,
+          },
+        },
+      },
+      smartContributions: {},
+    });
+  });
+});
+
+afterEach(async () => {
+  await act(async () => {
+    useStore.setState({
+      user: null,
+      tracking: {},
+      smartContributions: {},
+      selectedDate: originalSelectedDate,
+    });
+  });
+});
+
+  it('renders computed training load and metrics', async () => {
+    await act(async () => {
+      render(<TrainingLoadTile />);
+    });
+
+    expect(screen.getByTestId('training-load-tile')).toBeInTheDocument();
+    expect(screen.getByText('Training Load')).toBeInTheDocument();
+    expect(screen.getByText('300')).toBeInTheDocument();
+    expect(screen.getByTestId('training-load-sleep-value').textContent).toContain('8');
+    expect(screen.getByTestId('training-load-pushups-value').textContent).toContain('50');
+  });
+
+  it('shows fallback state when no data is present', async () => {
+    await act(async () => {
+      useStore.setState({ tracking: {} });
+    });
+
+    await act(async () => {
+      render(<TrainingLoadTile />);
+    });
+
+    expect(screen.getByText('Training Load')).toBeInTheDocument();
+    expect(screen.getByText('No data yet')).toBeInTheDocument();
+  });
+});

--- a/src/components/TrainingLoadTile.tsx
+++ b/src/components/TrainingLoadTile.tsx
@@ -54,7 +54,7 @@ function TrainingLoadTile() {
 
   const activeDate = selectedDate ?? new Date().toISOString().split('T')[0];
   const combinedDaily = useCombinedDailyTracking(activeDate);
-  const manualDaily = tracking.hasOwnProperty(activeDate) ? tracking[activeDate] : undefined;
+  const manualDaily = Object.prototype.hasOwnProperty.call(tracking, activeDate) ? tracking[activeDate] : undefined;
 
   const recoverySource = manualDaily?.recovery ?? combinedDaily?.recovery;
   const sessions = useMemo(

--- a/src/components/TrainingLoadTile.tsx
+++ b/src/components/TrainingLoadTile.tsx
@@ -54,7 +54,7 @@ function TrainingLoadTile() {
 
   const activeDate = selectedDate ?? new Date().toISOString().split('T')[0];
   const combinedDaily = useCombinedDailyTracking(activeDate);
-  const manualDaily = tracking[activeDate] ?? undefined;
+  const manualDaily = activeDate in tracking ? tracking[activeDate] : undefined;
 
   const recoverySource = manualDaily?.recovery ?? combinedDaily?.recovery;
   const sessions = useMemo(

--- a/src/components/TrainingLoadTile.tsx
+++ b/src/components/TrainingLoadTile.tsx
@@ -54,7 +54,7 @@ function TrainingLoadTile() {
 
   const activeDate = selectedDate ?? new Date().toISOString().split('T')[0];
   const combinedDaily = useCombinedDailyTracking(activeDate);
-  const manualDaily = tracking[activeDate];
+  const manualDaily = tracking.hasOwnProperty(activeDate) ? tracking[activeDate] : undefined;
 
   const recoverySource = manualDaily?.recovery ?? combinedDaily?.recovery;
   const sessions = useMemo(

--- a/src/components/TrainingLoadTile.tsx
+++ b/src/components/TrainingLoadTile.tsx
@@ -54,7 +54,7 @@ function TrainingLoadTile() {
 
   const activeDate = selectedDate ?? new Date().toISOString().split('T')[0];
   const combinedDaily = useCombinedDailyTracking(activeDate);
-  const manualDaily = activeDate in tracking ? tracking[activeDate] : undefined;
+  const manualDaily = tracking.hasOwnProperty(activeDate) ? tracking[activeDate] : undefined;
 
   const recoverySource = manualDaily?.recovery ?? combinedDaily?.recovery;
   const sessions = useMemo(

--- a/src/components/TrainingLoadTile.tsx
+++ b/src/components/TrainingLoadTile.tsx
@@ -1,0 +1,192 @@
+import { useMemo } from 'react';
+import { computeTrainingLoad, type DayRecovery, type DaySession } from '../logic/trainingLoad';
+import { useCombinedDailyTracking } from '../hooks/useCombinedTracking';
+import { useStore } from '../store/useStore';
+import { getTileClasses, designTokens } from '../theme/tokens';
+import { normalizeSports } from '../utils/sports';
+import { useTranslation } from '../hooks/useTranslation';
+
+const MAX_TRAINING_LOAD = 1500;
+
+const clampNumber = (value: number | undefined, fallback: number): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return fallback;
+  }
+  return value;
+};
+
+const formatScore = (value: number): string => {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}` : rounded.toFixed(1);
+};
+
+function buildSessions(
+  sportsSource: Parameters<typeof normalizeSports>[0]
+): DaySession[] {
+  const normalized = normalizeSports(sportsSource);
+
+  return Object.entries(normalized).reduce<DaySession[]>((sessions, [key, entry]) => {
+    if (!entry.active) {
+      return sessions;
+    }
+
+    const duration = clampNumber(entry.duration, 0);
+    const intensity = clampNumber(entry.intensity, 0);
+
+    if (duration <= 0 || intensity <= 0) {
+      return sessions;
+    }
+
+    sessions.push({
+      type: key,
+      duration,
+      intensity,
+    });
+
+    return sessions;
+  }, []);
+}
+
+function TrainingLoadTile() {
+  const { t } = useTranslation();
+  const tracking = useStore((state) => state.tracking);
+  const selectedDate = useStore((state) => state.selectedDate);
+
+  const activeDate = selectedDate ?? new Date().toISOString().split('T')[0];
+  const combinedDaily = useCombinedDailyTracking(activeDate);
+  const manualDaily = tracking[activeDate];
+
+  const recoverySource = manualDaily?.recovery ?? combinedDaily?.recovery;
+  const sessions = useMemo(
+    () => buildSessions(combinedDaily?.sports ?? manualDaily?.sports),
+    [combinedDaily?.sports, manualDaily?.sports]
+  );
+
+  const pushupsTotal = clampNumber(
+    combinedDaily?.pushups?.total ?? manualDaily?.pushups?.total,
+    0
+  );
+
+  const sleepQuality = clampNumber(recoverySource?.sleepQuality, 5);
+  const recoveryScore = clampNumber(recoverySource?.recovery, 5);
+  const illness = Boolean(recoverySource?.illness);
+
+  const recoveryTracked =
+    recoverySource?.sleepQuality !== undefined || recoverySource?.recovery !== undefined;
+  const pushupsTracked = pushupsTotal > 0;
+  const sportsTracked = sessions.length > 0;
+
+  const loadInput: DayRecovery = {
+    sleepQuality,
+    recovery: recoveryScore,
+    illness,
+    sessions,
+    pushupsTotal,
+  };
+
+  const trainingLoad = computeTrainingLoad(loadInput);
+  const percent = Math.min(
+    100,
+    Math.max(0, Math.round((trainingLoad / MAX_TRAINING_LOAD) * 100))
+  );
+
+  const statusKey: 'low' | 'optimal' | 'high' = trainingLoad >= 900 ? 'high' : trainingLoad >= 300 ? 'optimal' : 'low';
+  const statusLabel = t(`dashboard.trainingLoadStatus.${statusKey}`);
+  const hasData = recoveryTracked || pushupsTracked || sportsTracked;
+  const description = hasData
+    ? t('dashboard.trainingLoadSubtitle')
+    : t('dashboard.trainingLoadNoData');
+
+  const totalDuration = sessions.reduce((total, session) => total + session.duration, 0);
+  const workoutsDisplay = sportsTracked
+    ? `${sessions.length} · ${Math.round(totalDuration)} min`
+    : '—';
+  const sleepDisplay = recoveryTracked ? `${formatScore(sleepQuality)}/10` : '—';
+  const recoveryDisplay = recoveryTracked ? `${formatScore(recoveryScore)}/10` : '—';
+  const pushupDisplay = pushupsTracked ? `${pushupsTotal}` : '—';
+
+  return (
+    <div
+      className={`w-full ${getTileClasses(hasData)} ${designTokens.padding.compact} text-left text-white`}
+      data-testid="training-load-tile"
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <span className="text-xl" aria-hidden>
+            📈
+          </span>
+          <h3 className="text-xs font-medium text-gray-100/80 dark:text-gray-100/70">
+            {t('dashboard.trainingLoad')}
+          </h3>
+        </div>
+        <div className="text-sm font-bold text-winter-50 dark:text-winter-300">
+          {trainingLoad}
+        </div>
+      </div>
+
+      <p className="text-[11px] text-gray-100/70 dark:text-gray-100/60 mb-3">{description}</p>
+
+      <div className="mt-1">
+        <div className="flex items-center justify-between text-[11px] font-medium text-gray-100/80 mb-1">
+          <span>{statusLabel}</span>
+          <span>{percent}%</span>
+        </div>
+        <div className="h-2 w-full rounded-full bg-white/10 overflow-hidden">
+          <div
+            className="h-full bg-gradient-to-r from-winter-400 via-winter-500 to-winter-600 transition-all duration-500"
+            style={{ width: `${percent}%` }}
+            aria-hidden
+          />
+        </div>
+      </div>
+
+      <div className="mt-3 grid grid-cols-3 gap-2 text-[10px] text-gray-100/80">
+        <div className="rounded-xl bg-white/10 px-2 py-2">
+          <div className="text-[9px] uppercase tracking-wide text-gray-100/60">
+            {t('dashboard.trainingLoadSleep')}
+          </div>
+          <div
+            className="font-semibold text-gray-50 dark:text-white"
+            data-testid="training-load-sleep-value"
+          >
+            {sleepDisplay}
+          </div>
+        </div>
+        <div className="rounded-xl bg-white/10 px-2 py-2">
+          <div className="text-[9px] uppercase tracking-wide text-gray-100/60">
+            {t('dashboard.trainingLoadRecovery')}
+          </div>
+          <div
+            className="font-semibold text-gray-50 dark:text-white"
+            data-testid="training-load-recovery-value"
+          >
+            {recoveryDisplay}
+          </div>
+        </div>
+        <div className="rounded-xl bg-white/10 px-2 py-2">
+          <div className="text-[9px] uppercase tracking-wide text-gray-100/60">
+            {t('dashboard.trainingLoadWorkouts')}
+          </div>
+          <div
+            className="font-semibold text-gray-50 dark:text-white"
+            data-testid="training-load-workouts-value"
+          >
+            {workoutsDisplay}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 rounded-xl bg-white/5 px-3 py-2 text-[11px] text-gray-100/80">
+        <span className="text-gray-100/60">{t('dashboard.trainingLoadPushups')}:</span>{' '}
+        <span
+          className="font-semibold text-gray-50 dark:text-white"
+          data-testid="training-load-pushups-value"
+        >
+          {pushupDisplay}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default TrainingLoadTile;

--- a/src/components/TrainingLoadTile.tsx
+++ b/src/components/TrainingLoadTile.tsx
@@ -54,7 +54,7 @@ function TrainingLoadTile() {
 
   const activeDate = selectedDate ?? new Date().toISOString().split('T')[0];
   const combinedDaily = useCombinedDailyTracking(activeDate);
-  const manualDaily = Object.prototype.hasOwnProperty.call(tracking, activeDate) ? tracking[activeDate] : undefined;
+  const manualDaily = tracking[activeDate] ?? undefined;
 
   const recoverySource = manualDaily?.recovery ?? combinedDaily?.recovery;
   const sessions = useMemo(

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -30,6 +30,18 @@ export const translations = {
       waterProgress: 'Wasserfortschritt: {{percent}}% ({{day}})',
       minTasks: 'Mind. {{minTasks}} Aufgaben ({{totalTasksDone}}/35 {{tasks}})',
       today: 'Heute',
+      trainingLoad: 'Trainingslast',
+      trainingLoadSubtitle: 'Berechnet aus Schlaf, Regeneration & Workouts',
+      trainingLoadStatus: {
+        low: 'Niedrig',
+        optimal: 'Optimal',
+        high: 'Hoch',
+      },
+      trainingLoadSleep: 'Schlaf',
+      trainingLoadRecovery: 'Regeneration',
+      trainingLoadWorkouts: 'Sessions',
+      trainingLoadPushups: 'Liegestütze',
+      trainingLoadNoData: 'Noch keine Daten erfasst',
     },
     // Weather
     weather: {
@@ -297,6 +309,18 @@ export const translations = {
       waterProgress: 'Water progress: {{percent}}% ({{day}})',
       minTasks: 'Min. {{minTasks}} tasks ({{totalTasksDone}}/35 {{tasks}})',
       today: 'Today',
+      trainingLoad: 'Training Load',
+      trainingLoadSubtitle: 'Calculated from sleep, recovery & workouts',
+      trainingLoadStatus: {
+        low: 'Low',
+        optimal: 'Optimal',
+        high: 'High',
+      },
+      trainingLoadSleep: 'Sleep',
+      trainingLoadRecovery: 'Recovery',
+      trainingLoadWorkouts: 'Sessions',
+      trainingLoadPushups: 'Pushups',
+      trainingLoadNoData: 'No data yet',
     },
     // Weather
     weather: {

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -3,6 +3,7 @@ import SportTile from '../components/SportTile';
 import WaterTile from '../components/WaterTile';
 import ProteinTile from '../components/ProteinTile';
 import WeightTile from '../components/WeightTile';
+import TrainingLoadTile from '../components/TrainingLoadTile';
 import StreakMiniCard from '../components/dashboard/StreakMiniCard';
 import WeatherCard from '../components/dashboard/WeatherCard';
 import WeekCompactCard from '../components/dashboard/WeekCompactCard';
@@ -113,6 +114,7 @@ function DashboardPage() {
             if (enabledActivities.includes('sports')) tiles.push(<SportTile key="sports" />);
             if (enabledActivities.includes('water')) tiles.push(<WaterTile key="water" />);
             if (enabledActivities.includes('protein')) tiles.push(<ProteinTile key="protein" />);
+            tiles.push(<TrainingLoadTile key="training-load" />);
 
             // Group tiles into pairs for tile-grid-2 layout
             const tileGroups = [];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,6 +62,11 @@ export interface DailyTracking {
   sports: SportTracking;
   water: number; // ml
   protein: number; // g
+  recovery?: {
+    sleepQuality?: number;
+    recovery?: number;
+    illness?: boolean;
+  };
   weight?: {
     value: number; // kg
     bodyFat?: number; // %

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -79,6 +79,7 @@ export function combineTrackingWithSmart(
     })();
 
     result[`${dateKey}`] = {
+      ...manual,
       date: manual?.date ?? dateKey,
       sports,
       water,


### PR DESCRIPTION
## Summary
- add a TrainingLoadTile component that derives recovery metrics from tracking data and feeds them to computeTrainingLoad
- surface the training load card on the dashboard and extend translations and tracking types to support recovery details
- cover the new card with unit tests and ensure combined tracking keeps manual recovery information

## Testing
- npm test -- TrainingLoadTile.test.tsx
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e5806abd7c8333be6cfbd813bb66a8