### PR TITLE
Adjust dashboard top tiles layout for mobile

### DIFF
--- a/src/components/dashboard/StreakMiniCard.tsx
+++ b/src/components/dashboard/StreakMiniCard.tsx
@@ -8,7 +8,7 @@ export default function StreakMiniCard({ days }: StreakMiniCardProps) {
   const { t } = useTranslation();
 
   return (
-    <div className="rounded-2xl bg-white/5 dark:bg-white/5 backdrop-blur-md border border-white/10 shadow-[0_6px_24px_rgba(0,0,0,0.25)] p-4 h-[88px] sm:h-[76px] lg:h-[88px] flex items-center gap-3 transition-all duration-200 hover:bg-white/8">
+    <div className="relative w-full rounded-2xl bg-white/5 dark:bg-white/5 backdrop-blur-md border border-white/10 shadow-[0_6px_24px_rgba(0,0,0,0.25)] p-4 h-[88px] sm:h-[76px] lg:h-[88px] flex items-center gap-3 transition-all duration-200 hover:bg-white/8">
       {/* Fire Icon */}
       <div className="text-4xl flex-shrink-0">
         🔥

--- a/src/components/dashboard/WeatherCard.tsx
+++ b/src/components/dashboard/WeatherCard.tsx
@@ -21,7 +21,7 @@ export default function WeatherCard({ tempC, condition, location = "Aachen", loa
   const { t } = useTranslation();
   if (loading) {
     return (
-      <div className="rounded-2xl bg-white/5 dark:bg-white/5 backdrop-blur-md border border-white/10 shadow-[0_6px_24px_rgba(0,0,0,0.25)] p-4 h-[88px] sm:h-[76px] lg:h-[88px] flex items-center justify-center">
+      <div className="relative w-full rounded-2xl bg-white/5 dark:bg-white/5 backdrop-blur-md border border-white/10 shadow-[0_6px_24px_rgba(0,0,0,0.25)] p-4 h-[88px] sm:h-[76px] lg:h-[88px] flex items-center justify-center">
         <div className="animate-pulse flex items-center gap-3 w-full">
           <div className="w-10 h-10 bg-white/10 rounded-full" />
           <div className="flex-1 space-y-2">
@@ -34,7 +34,7 @@ export default function WeatherCard({ tempC, condition, location = "Aachen", loa
   }
 
   return (
-    <div className="rounded-2xl bg-white/5 dark:bg-white/5 backdrop-blur-md border border-white/10 shadow-[0_6px_24px_rgba(0,0,0,0.25)] p-4 h-[88px] sm:h-[76px] lg:h-[88px] flex items-center gap-3 transition-all duration-200 hover:bg-white/8">
+    <div className="relative w-full rounded-2xl bg-white/5 dark:bg-white/5 backdrop-blur-md border border-white/10 shadow-[0_6px_24px_rgba(0,0,0,0.25)] p-4 h-[88px] sm:h-[76px] lg:h-[88px] flex items-center gap-3 transition-all duration-200 hover:bg-white/8">
       {/* Weather Icon */}
       <div className="text-4xl flex-shrink-0">
         {weatherIcons[condition]}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -79,19 +79,19 @@ function DashboardPage() {
       {/* Content */}
       <div className="mobile-container dashboard-container safe-pb px-3 pt-4 md:px-6 md:pt-8 lg:px-0 max-h-[calc(100vh-5rem)] viewport-safe">
         {/* Top Grid: Streak + Check-in + Weather */}
-        <div className="flex flex-col gap-2 lg:gap-4 mb-3 animate-fade-in-up sm:grid sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]">
+        <div className="grid grid-cols-3 gap-2 lg:gap-4 mb-3 animate-fade-in-up sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]">
           {/* Streak Card */}
-          <div>
+          <div className="h-full">
             <StreakMiniCard days={streak} />
           </div>
 
           {/* Check-in Button */}
-          <div className="sm:flex sm:items-stretch sm:justify-center">
+          <div className="flex items-stretch justify-center h-full">
             <CheckInButton />
           </div>
 
           {/* Weather Card */}
-          <div>
+          <div className="h-full">
             {weatherLoading ? (
               <WeatherCard tempC={0} condition="partly" loading={true} />
             ) : weather ? (


### PR DESCRIPTION
## Summary
- switch the dashboard header tiles to a three-column grid so streak, check-in, and weather stay side-by-side on mobile
- stretch the streak and weather cards to fill their grid columns for consistent sizing with the check-in button

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e61cc9ddcc83338128055fd807f2f9