### PR TITLE
Add storage upload error mapping and type-safe MSW handler

### DIFF
--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -5,6 +5,27 @@ import { auth, storage } from '../firebase/config';
 type UploadResult = { success: boolean; url?: string; error?: string };
 type DeleteResult = { success: boolean; error?: string };
 
+const firebaseErrorMap: Record<string, string> = {
+  'storage/unauthorized': 'storage_unauthorized',
+  'storage/canceled': 'storage_canceled',
+  'storage/retry-limit-exceeded': 'storage_retry_limit_exceeded',
+  'storage/quota-exceeded': 'storage_quota_exceeded',
+  'storage/object-not-found': 'storage_object_not_found',
+};
+
+function mapUploadError(error: unknown): UploadResult {
+  if (error instanceof FirebaseError) {
+    const mappedError = firebaseErrorMap[error.code] ?? 'storage_error';
+    return { success: false, error: mappedError };
+  }
+
+  if (error instanceof Error) {
+    return { success: false, error: error.message };
+  }
+
+  return { success: false, error: 'unknown_error' };
+}
+
 function validateCurrentUser(userId: string): UploadResult {
   const currentUser = auth.currentUser;
 

--- a/test/handlers/notesHandlers.ts
+++ b/test/handlers/notesHandlers.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
 export const notesHandlers = [
-  http.post('https://generativelanguage.googleapis.com/*', async ({ request }) => {
+  http.post('https://generativelanguage.googleapis.com/*', async ({ request }: { request: Request }) => {
     const body = await request.json().catch(() => ({}));
     return HttpResponse.json({
       candidates: [


### PR DESCRIPTION
## Summary
- add a helper to translate Firebase storage errors into consistent upload responses
- annotate the MSW notes handler request parameter to avoid implicit any usage during tests

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e62a9df06c8333993006497f2e6fd8