### PR TITLE
Fix router basename handling for subpath deployments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { ToastProvider } from './components/ui/ToastProvider';
 import { useAuth } from './hooks/useAuth';
 import { usePagePerf, useNetworkToast } from './hooks/usePagePerf';
 import packageJson from '../package.json';
+import { getRouterBasename } from './lib/router';
 
 const appVersion = packageJson?.version ?? '0.0.0';
 const versionLabel = `v${appVersion}`;
@@ -20,10 +21,13 @@ function App() {
   // Show network status toasts
   useNetworkToast();
 
+  const routerBaseName = getRouterBasename(import.meta.env.BASE_URL);
+
   return (
     <ToastProvider>
       <ErrorBoundary>
         <BrowserRouter
+          basename={routerBaseName}
           future={{
             v7_startTransition: true,
             v7_relativeSplatPath: true

--- a/src/__tests__/AppRouterBase.test.tsx
+++ b/src/__tests__/AppRouterBase.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getRouterBasename } from '../lib/router';
+
+describe('getRouterBasename', () => {
+  it('returns undefined for empty, root, or dot root bases', () => {
+    expect(getRouterBasename(undefined)).toBeUndefined();
+    expect(getRouterBasename('')).toBeUndefined();
+    expect(getRouterBasename('/')).toBeUndefined();
+    expect(getRouterBasename('./')).toBeUndefined();
+  });
+
+  it('normalizes trailing slashes and enforces leading slash', () => {
+    expect(getRouterBasename('/winter-arc-app/')).toBe('/winter-arc-app');
+    expect(getRouterBasename('winter-arc-app/')).toBe('/winter-arc-app');
+    expect(getRouterBasename('winter-arc-app')).toBe('/winter-arc-app');
+  });
+
+  it('ignores inputs that normalize back to root', () => {
+    expect(getRouterBasename('///')).toBeUndefined();
+    expect(getRouterBasename(' / ')).toBeUndefined();
+  });
+});

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -1,0 +1,21 @@
+export function getRouterBasename(rawBaseUrl: string | undefined): string | undefined {
+  if (!rawBaseUrl) {
+    return undefined;
+  }
+
+  const trimmed = rawBaseUrl.trim();
+  if (trimmed === '' || trimmed === '/' || trimmed === './') {
+    return undefined;
+  }
+
+  const withoutTrailingSlash = trimmed.replace(/\/+$/, '');
+  if (withoutTrailingSlash === '' || withoutTrailingSlash === '/') {
+    return undefined;
+  }
+
+  const normalized = withoutTrailingSlash.startsWith('/')
+    ? withoutTrailingSlash
+    : `/${withoutTrailingSlash.replace(/^\/+/, '')}`;
+
+  return normalized === '/' ? undefined : normalized;
+}


### PR DESCRIPTION
## Summary
- compute the router basename from Vite's BASE_URL and pass it to BrowserRouter so routes resolve under sub-path deployments
- add a shared helper to normalize BASE_URL values and unit tests that cover the helper's edge cases

## Testing
- npm run lint
- npm run typecheck
- npm test -- --coverage

------
https://chatgpt.com/codex/tasks/task_e_68e6b52f1f488333a868eb75f28e31c2