### PR TITLE
Pin @sentry/react runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
-        "@sentry/react": "^10.18.0",
+        "@sentry/react": "10.18.0",
         "date-fns": "^4.1.0",
         "dexie": "^4.2.1",
         "firebase": "^12.3.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
-    "@sentry/react": "^10.18.0",
+    "@sentry/react": "10.18.0",
     "date-fns": "^4.1.0",
     "dexie": "^4.2.1",
     "firebase": "^12.3.0",


### PR DESCRIPTION
## Summary
- pin `@sentry/react` as a runtime dependency to ensure it is explicitly installed
- update the lockfile to match the pinned version

## Testing
- npm run lint
- npm run typecheck
- npm test -- --coverage

------
https://chatgpt.com/codex/tasks/task_e_68e6be121410833393a8de8aa5dbe765