### PR TITLE
Allow hosted domains for storage CORS

### DIFF
--- a/cors.json
+++ b/cors.json
@@ -1,6 +1,12 @@
 [
   {
-    "origin": ["https://winterarc.newrealm.de", "http://localhost:5173"],
+    "origin": [
+      "https://winterarc.newrealm.de",
+      "https://www.winterarc.newrealm.de",
+      "https://winterarc.app",
+      "https://www.winterarc.app",
+      "http://localhost:5173"
+    ],
     "method": ["GET", "POST", "PUT", "DELETE"],
     "maxAgeSeconds": 3600
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -35,23 +35,24 @@ if (import.meta.env.VITE_SENTRY_DSN) {
   });
   console.warn('✅ Sentry initialized');
 } else {
-  console.warn('⚠️ Sentry DSN not configured');
-Sentry.init({
-  dsn:
-    import.meta.env.VITE_SENTRY_DSN ??
-    'https://a6c368bdbb6514ab4e4f989f23d882d4@o4510114201731072.ingest.de.sentry.io/4510155533516880',
-  environment: import.meta.env.MODE,
-  sendDefaultPii: true,
-  integrations: [
-    Sentry.browserTracingIntegration(),
-    Sentry.replayIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-  tracePropagationTargets: ['localhost', /^https:\/\/yourserver\.io\/api/],
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
-  enableLogs: true,
-})
+  console.warn('⚠️ Sentry DSN not configured')
+  Sentry.init({
+    dsn:
+      import.meta.env.VITE_SENTRY_DSN ??
+      'https://a6c368bdbb6514ab4e4f989f23d882d4@o4510114201731072.ingest.de.sentry.io/4510155533516880',
+    environment: import.meta.env.MODE,
+    sendDefaultPii: true,
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.replayIntegration(),
+    ],
+    tracesSampleRate: 1.0,
+    tracePropagationTargets: ['localhost', /^https:\/\/yourserver\.io\/api/],
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+    enableLogs: true,
+  })
+}
 
 const container = document.getElementById('root')
 


### PR DESCRIPTION
## Summary
- add winterarc.app and www hosts to the Firebase Storage CORS allow list so external users avoid blocked requests
- tidy the Sentry fallback initialization block so the file parses correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6c164a26c833386802c5f3b00aab5