### PR TITLE
Fix Firebase imports for dashboard and check-in modules

### DIFF
--- a/src/components/dashboard/WeeklyTile.tsx
+++ b/src/components/dashboard/WeeklyTile.tsx
@@ -13,7 +13,7 @@ import DayCircle, { DayCircleSkeleton } from '../ui/DayCircle';
 import { useTranslation } from '../../hooks/useTranslation';
 import { useWeekContext } from '../../contexts/WeekContext';
 import { useStore } from '../../store/useStore';
-import { db } from '../../firebase/config';
+import { db } from '../../firebase';
 import type { Activity, DailyTracking } from '../../types';
 import { getDayProgressSummary } from '../../utils/progress';
 import CheckInModal from '../checkin/CheckInModal';

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -5,11 +5,13 @@ import WaterTile from '../components/WaterTile';
 import ProteinTile from '../components/ProteinTile';
 import WeightTile from '../components/WeightTile';
 import TrainingLoadTile from '../components/TrainingLoadTile';
+import WeeklyTile from '../components/dashboard/WeeklyTile';
+import { WeekProvider } from '../contexts/WeekContext';
+import { useTrackingEntries } from '../hooks/useTrackingEntries';
+import { useTranslation } from '../hooks/useTranslation';
 import { useTracking } from '../hooks/useTracking';
 import { useWeeklyTop3 } from '../hooks/useWeeklyTop3';
 import { useStore } from '../store/useStore';
-import { WeekProvider } from '../contexts/WeekContext';
-import WeeklyTile from '../components/dashboard/WeeklyTile';
 
 function DashboardPage() {
   const { t } = useTranslation();

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,8 +1,6 @@
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { signOut } from 'firebase/auth';
-import * as Sentry from '@sentry/react';
 import { auth } from '../firebase';
-import { auth } from '../firebase/config';
 import { useStore } from '../store/useStore';
 import { Language, Activity } from '../types';
 import { useTranslation } from '../hooks/useTranslation';

--- a/src/services/checkin.ts
+++ b/src/services/checkin.ts
@@ -16,7 +16,7 @@ import {
   where,
 } from 'firebase/firestore';
 import packageJson from '../../package.json';
-import { auth, db } from '../firebase/config';
+import { auth, db } from '../firebase';
 import type { DailyTracking, DailyCheckIn, DailyTrainingLoad, User } from '../types';
 import {
   buildWorkoutEntriesFromTracking,


### PR DESCRIPTION
## Summary
- update shared Firebase consumers to import auth and db from the central firebase entrypoint
- restore missing hook imports on the dashboard page to re-enable translations and tracking error handling
- remove duplicate and unused Firebase/Sentry imports on the settings page

## Testing
- npm run typecheck
- npm run build *(fails: missing @sentry/vite-plugin from Vite config)*

------
https://chatgpt.com/codex/tasks/task_e_68e6cb441ef083338767f30754125783