### PR TITLE
🔧 CRITICAL: Fix deployment workflows to deploy correct branches

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: main  # Explicitly checkout main branch for production
 
       - name: Setup dependencies
         uses: ./.github/actions/setup-deps

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: develop  # Explicitly checkout develop branch for staging
 
       - name: Setup dependencies
         uses: ./.github/actions/setup-deps


### PR DESCRIPTION
## 🚨 CRITICAL FIX

Deployment workflows were deploying **wrong branches**, causing:
- ❌ Staging showed OLD code from main instead of develop
- ⚠️ Production could potentially deploy wrong branch

## 🔍 Root Cause

`workflow_run` events lose branch context, causing `checkout@v4` to default to `main` branch.

**Result:**
- Staging deployed `main` (old) instead of `develop` (new with redesign)
- Production happened to work (both default to main) but not robust

## ✅ Solution

### 1. CI Workflow Triggers (from PR #166)
```yaml
# ci.yml
on:
  push:
    branches: [develop, main]  # Trigger deployments
  pull_request:  # Validate PRs
```

### 2. Explicit Branch Checkout (NEW)
```yaml
# deploy-staging.yml
- uses: actions/checkout@v4
  with:
    ref: develop  # ✅ Explicitly checkout develop

# deploy-production.yml  
- uses: actions/checkout@v4
  with:
    ref: main  # ✅ Explicitly checkout main
```

## 📊 What This Fixes

| Workflow | Before | After |
|----------|--------|-------|
| **Staging** | ❌ Deployed main (old code) | ✅ Deploys develop (latest features) |
| **Production** | ⚠️ Deployed main (worked but fragile) | ✅ Explicitly deploys main (robust) |

## 🧪 Testing

After merge:
- [ ] Staging should show redesign from develop
- [ ] Production remains stable on main
- [ ] Both workflows deploy correct branches

## 🔗 URLs

- **Staging**: https://staging.winterarc.newrealm.de (should show develop)
- **Production**: https://app.winterarc.newrealm.de (should show main)

## 🎯 Expected Behavior

```
develop commits → CI runs → Staging deploys develop ✅
main commits    → CI runs → Production deploys main ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)