### PR TITLE
Improve client auth guards on dashboard and related pages

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useStore } from '../store/useStore';
 import { useAuth } from '../hooks/useAuth';
-import { redirect } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import Layout from '../components/Layout';
 import PushupTile from '../components/PushupTile';
 import WeightTile from '../components/WeightTile';
@@ -14,17 +14,40 @@ import PWAInstallPrompt from '../components/PWAInstallPrompt';
 import SystemIndicator from '../components/SystemIndicator';
 import { CardSkeleton } from '../components/ui/Skeleton';
 
+function LoadingScreen() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-winter-500 to-winter-700">
+      <div className="text-center">
+        <div className="text-6xl mb-4">❄️</div>
+        <div className="text-white text-lg font-semibold">Loading...</div>
+      </div>
+    </div>
+  );
+}
+
 function DashboardContent() {
+  const router = useRouter();
   const user = useStore((state) => state.user);
   const isOnboarded = useStore((state) => state.isOnboarded);
+  const authLoading = useStore((state) => state.authLoading);
 
-  // Client-side authentication check
-  if (!user) {
-    redirect('/auth/signin');
-  }
+  useEffect(() => {
+    if (authLoading) {
+      return;
+    }
 
-  if (!isOnboarded) {
-    redirect('/onboarding');
+    if (!user) {
+      router.replace('/auth/signin');
+      return;
+    }
+
+    if (!isOnboarded) {
+      router.replace('/onboarding');
+    }
+  }, [authLoading, isOnboarded, router, user]);
+
+  if (authLoading || !user || !isOnboarded) {
+    return <LoadingScreen />;
   }
 
   return (
@@ -69,14 +92,7 @@ export default function DashboardPage() {
   useAuth();
 
   return (
-    <Suspense fallback={
-      <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-winter-500 to-winter-700">
-        <div className="text-center">
-          <div className="text-6xl mb-4">❄️</div>
-          <div className="text-white text-lg font-semibold">Loading...</div>
-        </div>
-      </div>
-    }>
+    <Suspense fallback={<LoadingScreen />}>
       <DashboardContent />
     </Suspense>
   );

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,17 +1,39 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useStore } from '../store/useStore';
 import { useAuth } from '../hooks/useAuth';
-import { redirect } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import Layout from '../components/Layout';
-import { CardSkeleton } from '../components/ui/Skeleton';
+
+function LoadingScreen() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-winter-500 to-winter-700">
+      <div className="text-center">
+        <div className="text-6xl mb-4">❄️</div>
+        <div className="text-white text-lg font-semibold">Loading...</div>
+      </div>
+    </div>
+  );
+}
 
 function LeaderboardContent() {
+  const router = useRouter();
   const user = useStore((state) => state.user);
+  const authLoading = useStore((state) => state.authLoading);
 
-  if (!user) {
-    redirect('/auth/signin');
+  useEffect(() => {
+    if (authLoading) {
+      return;
+    }
+
+    if (!user) {
+      router.replace('/auth/signin');
+    }
+  }, [authLoading, router, user]);
+
+  if (authLoading || !user) {
+    return <LoadingScreen />;
   }
 
   return (
@@ -47,7 +69,7 @@ export default function LeaderboardPage() {
   useAuth();
 
   return (
-    <Suspense fallback={<CardSkeleton />}>
+    <Suspense fallback={<LoadingScreen />}>
       <LeaderboardContent />
     </Suspense>
   );

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,17 +1,39 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useStore } from '../store/useStore';
 import { useAuth } from '../hooks/useAuth';
-import { redirect } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import Layout from '../components/Layout';
-import { CardSkeleton } from '../components/ui/Skeleton';
+
+function LoadingScreen() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-winter-500 to-winter-700">
+      <div className="text-center">
+        <div className="text-6xl mb-4">❄️</div>
+        <div className="text-white text-lg font-semibold">Loading...</div>
+      </div>
+    </div>
+  );
+}
 
 function SettingsContent() {
+  const router = useRouter();
   const user = useStore((state) => state.user);
+  const authLoading = useStore((state) => state.authLoading);
 
-  if (!user) {
-    redirect('/auth/signin');
+  useEffect(() => {
+    if (authLoading) {
+      return;
+    }
+
+    if (!user) {
+      router.replace('/auth/signin');
+    }
+  }, [authLoading, router, user]);
+
+  if (authLoading || !user) {
+    return <LoadingScreen />;
   }
 
   return (
@@ -53,7 +75,7 @@ export default function SettingsPage() {
   useAuth();
 
   return (
-    <Suspense fallback={<CardSkeleton />}>
+    <Suspense fallback={<LoadingScreen />}>
       <SettingsContent />
     </Suspense>
   );


### PR DESCRIPTION
## Summary
- replace client-side `redirect` calls on the dashboard, leaderboard, and settings pages with router-driven navigation to avoid render-time crashes
- show a consistent full-screen loading state while the auth hook resolves before rendering protected content
- ensure unauthenticated visitors are redirected toward sign-in without triggering client-side errors

## Testing
- npm run lint *(fails: missing eslint-config-next in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185a27fe2c833389e28a32c8bac606)