### PR TITLE
Update dashboard nav and scaffold input page

### DIFF
--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -19,12 +19,11 @@ function Layout({ children }: LayoutProps) {
   const user = useStore((state) => state.user);
 
   // Hide BottomNav on mobile dashboard
-  const hiddenNavOnMobileDashboard = isMobile && pathname === '/';
+  const hiddenNavOnMobileDashboard = isMobile && pathname.startsWith('/dashboard');
 
   const navItems = [
-    { path: '/', labelKey: 'nav.dashboard', icon: '🏠' },
+    { path: '/dashboard', labelKey: 'nav.dashboard', icon: '🏠' },
     { path: '/leaderboard', labelKey: 'nav.group', icon: '👥' },
-    { path: '/input', labelKey: 'nav.input', icon: '📝' },
     { path: '/settings', labelKey: 'nav.settings', icon: user?.photoURL ? null : '⚙️', showAvatar: true },
   ];
 
@@ -46,7 +45,9 @@ function Layout({ children }: LayoutProps) {
         >
           <div className="flex items-center justify-center gap-4 animate-fade-in-up delay-400">
             {navItems.map((item) => {
-              const isActive = pathname === item.path;
+              const isActive =
+                pathname === item.path ||
+                (item.path !== '/' && pathname.startsWith(`${item.path}/`));
               const slug = item.path.replace(/^\//, '').replace(/\//g, '-') || 'dashboard';
               return (
                 <Link

--- a/app/input/page.tsx
+++ b/app/input/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Suspense } from 'react';
+import { redirect } from 'next/navigation';
+import Layout from '../components/Layout';
+import { useAuth } from '../hooks/useAuth';
+import { useStore } from '../store/useStore';
+import { CardSkeleton } from '../components/ui/Skeleton';
+
+function InputContent() {
+  const user = useStore((state) => state.user);
+  const isOnboarded = useStore((state) => state.isOnboarded);
+
+  if (!user) {
+    redirect('/auth/signin');
+  }
+
+  if (!isOnboarded) {
+    redirect('/onboarding');
+  }
+
+  return (
+    <Layout>
+      <div className="space-y-6 p-4">
+        <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+          <h1 className="text-2xl font-bold text-white mb-2">Input</h1>
+          <p className="text-white/80">
+            Manual entry tools are coming soon. Stay tuned for streamlined tracking.
+          </p>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+export default function InputPage() {
+  useAuth();
+
+  return (
+    <Suspense fallback={<CardSkeleton />}>
+      <InputContent />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary
- point the dashboard navigation item to `/dashboard` and drop the unused `/input` shortcut
- ensure the active nav state tracks nested routes via `usePathname`
- scaffold a placeholder input page to keep the route available

## Testing
- npm run lint:code *(fails: Cannot find package 'eslint-config-next' in the current environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185a28b8448333a016b14958d866cb)