### PR TITLE
Align local env template with Next.js stack

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -1,46 +1,41 @@
 # ============================================
-# Winter Arc Backend - Environment Variables
+# Winter Arc App – Local Environment Template
 # ============================================
+# Copy this file to `.env.local` and fill in the
+# required values before running the development server.
 #
-# ANLEITUNG:
-# 1. Kopiere diese Datei zu `.env.local`
-# 2. Fülle ALLE Werte aus
-# 3. .env.local ist gitignored (sicher!)
-#
-# Für Vercel Production:
-# - Gehe zu Vercel Dashboard → Settings → Environment Variables
-# - Füge diese Variablen dort ein
-# ============================================
+# This template mirrors the variables in `.env.example`
+# to keep local development and deployment in sync.
+# --------------------------------------------
+# Database (Neon / Vercel Postgres)
+# --------------------------------------------
+DATABASE_URL="postgresql://user:password@hostname/database"
 
 # --------------------------------------------
-# Firebase Admin SDK (für Backend API)
+# NextAuth Configuration
 # --------------------------------------------
-# Gehe zu: Firebase Console → Project Settings → Service Accounts
-# Klicke: "Generate New Private Key"
-
-FIREBASE_PROJECT_ID=
-FIREBASE_CLIENT_EMAIL=
-FIREBASE_PRIVATE_KEY=
-
-# WICHTIG: Private Key muss Newlines beibehalten!
-# Format: "-----BEGIN PRIVATE KEY-----\nXXX...\n-----END PRIVATE KEY-----\n"
+NEXTAUTH_SECRET="your-nextauth-secret-here"
+NEXTAUTH_URL="http://localhost:3000"
 
 # --------------------------------------------
-# Google Gemini AI (für Smart Quotes)
+# Google OAuth (used by NextAuth)
 # --------------------------------------------
-# Gehe zu: https://makersuite.google.com/app/apikey
-
-GEMINI_API_KEY=
-
-# --------------------------------------------
-# Frontend URL (für CORS)
-# --------------------------------------------
-# Lokal: http://localhost:5173
-# Production: https://app.winterarc.newrealm.de
-
-FRONTEND_URL=http://localhost:5173
+GOOGLE_CLIENT_ID="your-google-client-id"
+GOOGLE_CLIENT_SECRET="your-google-client-secret"
 
 # --------------------------------------------
-# Umgebung
+# Optional: Gemini API for smart notes
 # --------------------------------------------
-NODE_ENV=development
+GEMINI_API_KEY="your-gemini-api-key"
+
+# --------------------------------------------
+# Optional: Sentry for error tracking
+# --------------------------------------------
+NEXT_PUBLIC_SENTRY_DSN="your-sentry-dsn"
+
+# --------------------------------------------
+# Legacy Firebase configuration
+# --------------------------------------------
+# Firebase-specific environment variables have been
+# moved to docs/archive/firebase-env.md for teams that
+# still maintain the old integration.

--- a/docs/archive/firebase-env.md
+++ b/docs/archive/firebase-env.md
@@ -1,0 +1,19 @@
+# Legacy Firebase Environment Variables
+
+> **Status:** Archived – only required if you are maintaining the deprecated Firebase backend.
+
+The previous Firebase-based backend required the following environment variables:
+
+```env
+FIREBASE_PROJECT_ID=
+FIREBASE_CLIENT_EMAIL=
+FIREBASE_PRIVATE_KEY=
+```
+
+To regenerate credentials:
+
+1. Open the Firebase Console and navigate to **Project Settings → Service Accounts**.
+2. Click **Generate New Private Key** to download a JSON file.
+3. Copy the values into the variables above. Preserve newlines in `FIREBASE_PRIVATE_KEY` by replacing actual newlines with `\n` when storing in `.env` files.
+
+These variables are no longer needed for the Next.js + Neon stack. Keep them separate from `.env.local` unless you are actively supporting the legacy service.

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -1,0 +1,19 @@
+# Winter Arc Development Guidelines
+
+## Environment Configuration
+
+Copy the provided template to create your local environment file:
+
+```bash
+cp .env.local.template .env.local
+```
+
+The template mirrors `.env.example` and includes the variables required for the Next.js stack:
+
+- `DATABASE_URL` – Neon/Vercel Postgres connection string
+- `NEXTAUTH_SECRET` and `NEXTAUTH_URL` – NextAuth configuration
+- `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` – Google OAuth credentials
+
+Optional integrations such as Gemini and Sentry are also documented in the template. Refer to [`docs/archive/firebase-env.md`](archive/firebase-env.md) if you still support the legacy Firebase backend.
+
+After populating `.env.local`, start the development server with `pnpm dev`.


### PR DESCRIPTION
## Summary
- rewrite `.env.local.template` to mirror the Next.js environment variables used in `.env.example`
- add development guidelines that point newcomers to the correct local env template
- archive the legacy Firebase environment variable instructions for teams that still need them

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185a2d30c88333a1ed313c86892771)