### PR TITLE
Update Sentry service to use Next.js environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,5 @@ GEMINI_API_KEY="your-gemini-api-key"
 
 # Optional: Sentry for error tracking
 NEXT_PUBLIC_SENTRY_DSN="your-sentry-dsn"
+# Optional: Disable Sentry telemetry (set to "true" for local tests)
+NEXT_PUBLIC_SENTRY_DISABLE="false"


### PR DESCRIPTION
## Summary
- guard the Sentry initializer so it only runs in the browser when a DSN is configured and honor Next.js runtime metadata
- short-circuit telemetry in tests or when `NEXT_PUBLIC_SENTRY_DISABLE` is set while reusing the helpers across capture utilities
- document the new `NEXT_PUBLIC_SENTRY_DISABLE` flag in `.env.example`

## Testing
- npm run lint:code *(fails: missing optional dependency `eslint-config-next` in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185a2bf2d08333b6e8a71892d0d2a5)